### PR TITLE
Configure .NET Aspire project startup

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,20 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "C#: Aspire Debug",
+            "type": "dotnet",
+            "request": "launch",
+            "projectPath": "${workspaceFolder}/JAIMES AF.AppHost/JAIMES AF.AppHost.csproj",
+            "program": "${workspaceFolder}/JAIMES AF.AppHost/bin/Debug/net9.0/JAIMES AF.AppHost.dll",
+            "args": [],
+            "cwd": "${workspaceFolder}/JAIMES AF.AppHost",
+            "stopAtEntry": false,
+            "console": "internalConsole",
+            "env": {
+                "ASPNETCORE_ENVIRONMENT": "Development"
+            },
+            "preLaunchTask": "build"
+        }
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,8 @@
+{
+    "dotnet.defaultSolution": "JAIMES AF.slnx",
+    "omnisharp.defaultLaunchSolution": "JAIMES AF.slnx",
+    "files.exclude": {
+        "**/bin": true,
+        "**/obj": true
+    }
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,36 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "build",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "build",
+                "${workspaceFolder}/JAIMES AF.AppHost/JAIMES AF.AppHost.csproj",
+                "/property:GenerateFullPaths=true",
+                "/consoleloggerparameters:NoSummary"
+            ],
+            "problemMatcher": "$msCompile",
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            }
+        },
+        {
+            "label": "run",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "run",
+                "--project",
+                "${workspaceFolder}/JAIMES AF.AppHost/JAIMES AF.AppHost.csproj"
+            ],
+            "problemMatcher": "$msCompile",
+            "group": {
+                "kind": "build",
+                "isDefault": false
+            }
+        }
+    ]
+}


### PR DESCRIPTION
Add VS Code launch, tasks, and settings configurations to enable building and running the .NET Aspire project and resolve 'Startup project not set' errors.

The existing setup lacked the necessary VS Code configurations to correctly identify and launch the .NET Aspire AppHost project, leading to the "Startup project not set" error. These configurations provide the specific project path, build tasks, and environment settings required for integrated debugging and running.

---
<a href="https://cursor.com/background-agent?bcId=bc-ca410e04-5d33-453e-a229-17b9c25b9f12"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ca410e04-5d33-453e-a229-17b9c25b9f12"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

