### PR TITLE
Configure .NET Aspire project startup

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,33 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Launch .NET Aspire AppHost",
+            "type": "dotnet",
+            "request": "launch",
+            "projectPath": "${workspaceFolder}/JAIMES AF.AppHost/JAIMES AF.AppHost.csproj",
+            "program": "${workspaceFolder}/JAIMES AF.AppHost/bin/Debug/net9.0/JAIMES AF.AppHost.dll",
+            "args": [],
+            "cwd": "${workspaceFolder}",
+            "console": "integratedTerminal",
+            "stopAtEntry": false,
+            "env": {
+                "ASPNETCORE_ENVIRONMENT": "Development"
+            }
+        },
+        {
+            "name": "Launch .NET Aspire AppHost (Release)",
+            "type": "dotnet",
+            "request": "launch",
+            "projectPath": "${workspaceFolder}/JAIMES AF.AppHost/JAIMES AF.AppHost.csproj",
+            "program": "${workspaceFolder}/JAIMES AF.AppHost/bin/Release/net9.0/JAIMES AF.AppHost.dll",
+            "args": [],
+            "cwd": "${workspaceFolder}",
+            "console": "integratedTerminal",
+            "stopAtEntry": false,
+            "env": {
+                "ASPNETCORE_ENVIRONMENT": "Production"
+            }
+        }
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+    "dotnet.defaultSolution": "JAIMES AF.slnx",
+    "omnisharp.defaultLaunchSolution": "JAIMES AF.slnx",
+    "dotnet.completion.showCompletionItemsFromUnimportedNamespaces": true,
+    "dotnet.server.useOmnisharp": false
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,45 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "build",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "build",
+                "${workspaceFolder}/JAIMES AF.AppHost/JAIMES AF.AppHost.csproj",
+                "/property:GenerateFullPaths=true",
+                "/consoleloggerparameters:NoSummary"
+            ],
+            "problemMatcher": "$msCompile",
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            }
+        },
+        {
+            "label": "publish",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "publish",
+                "${workspaceFolder}/JAIMES AF.AppHost/JAIMES AF.AppHost.csproj",
+                "/property:GenerateFullPaths=true",
+                "/consoleloggerparameters:NoSummary"
+            ],
+            "problemMatcher": "$msCompile"
+        },
+        {
+            "label": "watch",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "watch",
+                "run",
+                "--project",
+                "${workspaceFolder}/JAIMES AF.AppHost/JAIMES AF.AppHost.csproj"
+            ],
+            "problemMatcher": "$msCompile"
+        }
+    ]
+}


### PR DESCRIPTION
Add VS Code launch, tasks, and settings configurations to enable building and running the .NET Aspire project in Cursor, resolving the "Startup project not set" error.

The "Startup project not set" error occurs because the IDE (Cursor, based on VS Code) doesn't know which project to execute by default. The added `launch.json` explicitly defines the `JAIMES AF.AppHost.csproj` as the startup project for debugging, while `tasks.json` provides build/run tasks and `settings.json` improves C# extension integration.

---
<a href="https://cursor.com/background-agent?bcId=bc-aa0d87d2-0704-41f5-bba5-ce97aae94231"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-aa0d87d2-0704-41f5-bba5-ce97aae94231"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

