### PR TITLE
Fix failing tests and run dotnet test on PR

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,32 @@
+name: Run Tests
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '10.0.x'
+          dotnet-quality: 'preview'
+      
+      - name: Restore dependencies
+        run: dotnet restore
+      
+      - name: Build
+        run: dotnet build --no-restore --configuration Release
+      
+      - name: Run tests
+        run: dotnet test "JAIMES AF.Tests/JAIMES AF.Tests.csproj" --no-build --configuration Release --verbosity normal


### PR DESCRIPTION
Fix failing tests and add a GitHub Actions workflow to run tests on every pull request to main.

The existing tests were failing because the API service's dependencies (RabbitMQ connection, Chat Services) were not mocked in the test environment, leading to runtime exceptions. The `EndpointTestBase` was updated to mock these services, allowing all tests to pass.

---
Linear Issue: [MHE-14](https://linear.app/matteland/issue/MHE-14/run-dotnet-test-on-every-pull-request)

<a href="https://cursor.com/background-agent?bcId=bc-f2c3cd1d-e182-4cd9-be91-e06068b81269"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-f2c3cd1d-e182-4cd9-be91-e06068b81269"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a GitHub Actions workflow to build/test on main and updates test base to mock RabbitMQ and chat services.
> 
> - **CI**:
>   - Add workflow `/.github/workflows/test.yml` to build and run `dotnet test` on PRs and pushes to `main` using .NET `10.0.x` (preview).
> - **Tests**:
>   - Update `JAIMES AF.Tests/Endpoints/EndpointTestBase.cs` to configure test host with in-memory DB and mocked external services:
>     - Replace `IConnectionFactory`/RabbitMQ (`IConnection`, `IChannel`) with mocks and set `ConnectionStrings:messaging`.
>     - Mock `IMessagePublisher`.
>     - Mock `IChatService` (stub `GenerateInitialMessageAsync`) and `IChatHistoryService`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5b7ff4b8e9cc40deac598fa537f9cf83dfb6dc59. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->