### PR TITLE
Setup cursor cloud agent for dotnet 10

### DIFF
--- a/.cursor/Dockerfile
+++ b/.cursor/Dockerfile
@@ -1,0 +1,33 @@
+# syntax=docker/dockerfile:1
+
+FROM mcr.microsoft.com/devcontainers/base:ubuntu-24.04
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+# Install core build dependencies.
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        ca-certificates \
+        curl \
+        git \
+        jq \
+        unzip \
+        build-essential \
+        libicu-dev \
+        zlib1g && \
+    rm -rf /var/lib/apt/lists/*
+
+ENV DOTNET_ROOT=/usr/share/dotnet
+
+# Install the latest .NET 10 SDK via the official installer script.
+RUN curl -sSL https://dot.net/v1/dotnet-install.sh -o /tmp/dotnet-install.sh && \
+    chmod +x /tmp/dotnet-install.sh && \
+    /tmp/dotnet-install.sh --channel 10.0 --install-dir "${DOTNET_ROOT}" --no-path && \
+    rm /tmp/dotnet-install.sh && \
+    ln -sf "${DOTNET_ROOT}/dotnet" /usr/local/bin/dotnet && \
+    dotnet --info
+
+# Ensure the SDK directory is on PATH for any additional shells.
+ENV PATH="${DOTNET_ROOT}:${PATH}"
+
+WORKDIR /workspace

--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,3 +1,10 @@
 {
-  "agentCanUpdateSnapshot": true
+  "name": "jaimes-af-dotnet10",
+  "build": {
+    "dockerfile": "Dockerfile",
+    "context": "."
+  },
+  "snapshot": "POPULATED_FROM_SETTINGS",
+  "agentCanUpdateSnapshot": true,
+  "install": "dotnet restore 'JAIMES AF.AppHost/JAIMES AF.AppHost.csproj' && dotnet restore 'JAIMES AF.Tests/JAIMES AF.Tests.csproj'"
 }


### PR DESCRIPTION
Add .NET 10 SDK to the Cursor cloud agent environment and pre-restore dependencies to enable `dotnet build`.

---
<a href="https://cursor.com/background-agent?bcId=bc-35f3db28-a472-46bd-9798-c580839fd930"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-35f3db28-a472-46bd-9798-c580839fd930"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add a devcontainer Dockerfile installing .NET 10 SDK and update Cursor environment to build via Docker and pre-restore project dependencies.
> 
> - **Devcontainer**:
>   - Add `.cursor/Dockerfile` based on `ubuntu-24.04` installing core build deps and .NET 10 SDK via `dotnet-install.sh`; sets `DOTNET_ROOT`, updates `PATH`, and `WORKDIR`.
> - **Cursor Environment**:
>   - Update `.cursor/environment.json` to define `build` using the new `Dockerfile`, set `name` and `snapshot`, and add `install` to run `dotnet restore` for `JAIMES AF.AppHost/JAIMES AF.AppHost.csproj` and `JAIMES AF.Tests/JAIMES AF.Tests.csproj`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 167464fe25aaaf643f180350557fd6ffe1e63040. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->