### PR TITLE
Add Sentiment property to MessageDto and MessageResponse; update mappers and PlayerSentimentTool

### DIFF
--- a/JAIMES AF.Domain/MessageDto.cs
+++ b/JAIMES AF.Domain/MessageDto.cs
@@ -9,4 +9,5 @@ public class MessageDto
     public DateTime CreatedAt { get; init; }
     public string? AgentId { get; init; }
     public int? InstructionVersionId { get; init; }
+    public int? Sentiment { get; init; }
 }

--- a/JAIMES AF.ServiceDefinitions/Responses/MessageResponse.cs
+++ b/JAIMES AF.ServiceDefinitions/Responses/MessageResponse.cs
@@ -10,4 +10,5 @@ public record MessageResponse
     public DateTime CreatedAt { get; set; }
     public string? AgentId { get; set; }
     public int? InstructionVersionId { get; set; }
+    public int? Sentiment { get; set; }
 }

--- a/JAIMES AF.Services/Mapping/MessageMapper.cs
+++ b/JAIMES AF.Services/Mapping/MessageMapper.cs
@@ -17,7 +17,6 @@ public static partial class MessageMapper
     [MapperIgnoreSource(nameof(Message.PreviousMessage))]
     [MapperIgnoreSource(nameof(Message.NextMessageId))]
     [MapperIgnoreSource(nameof(Message.NextMessage))]
-    [MapperIgnoreSource(nameof(Message.Sentiment))]
     public static partial MessageDto ToDto(this Message message);
 
     public static partial MessageDto[] ToDto(this IEnumerable<Message> messages);

--- a/JAIMES AF.Services/Mapping/MessageResponseMapper.cs
+++ b/JAIMES AF.Services/Mapping/MessageResponseMapper.cs
@@ -10,6 +10,7 @@ public static partial class MessageResponseMapper
     [MapProperty(nameof(MessageDto.CreatedAt), nameof(MessageResponse.CreatedAt))]
     [MapProperty(nameof(MessageDto.AgentId), nameof(MessageResponse.AgentId))]
     [MapProperty(nameof(MessageDto.InstructionVersionId), nameof(MessageResponse.InstructionVersionId))]
+    [MapProperty(nameof(MessageDto.Sentiment), nameof(MessageResponse.Sentiment))]
     [MapProperty(nameof(MessageDto.PlayerId),
         nameof(MessageResponse.Participant),
         Use = nameof(MapParticipantFromPlayerId))]

--- a/JAIMES AF.Tools/PlayerSentimentTool.cs
+++ b/JAIMES AF.Tools/PlayerSentimentTool.cs
@@ -56,8 +56,22 @@ public class PlayerSentimentTool(GameDto game, IServiceProvider serviceProvider)
             return "No sentiment analysis results available for this player in the current game.";
         }
 
+        // Calculate average sentiment
+        double averageSentiment = messagesWithSentiment.Average(m => m.Sentiment!.Value);
+        string averageLabel = averageSentiment switch
+        {
+            > 0.33 => "Positive",
+            < -0.33 => "Negative",
+            _ => "Neutral"
+        };
+
         // Format results
         List<string> resultTexts = new();
+        
+        // Add average sentiment at the beginning
+        resultTexts.Add($"Average Sentiment: {averageLabel} ({averageSentiment:F2})");
+        resultTexts.Add(string.Empty); // Empty line separator
+        
         foreach (Message message in messagesWithSentiment)
         {
             string sentimentLabel = message.Sentiment switch

--- a/JAIMES AF.Web/Components/Layout/NavMenu.razor
+++ b/JAIMES AF.Web/Components/Layout/NavMenu.razor
@@ -5,11 +5,15 @@
   <MudNavLink Href="/scenarios" Icon="Icons.Material.Filled.MenuBook">Scenarios</MudNavLink>
   <MudNavLink Href="/players" Icon="Icons.Material.Filled.Person">Players</MudNavLink>
  </MudNavGroup>
+ <MudNavGroup Title="Tools" Icon="Icons.Material.Filled.Build" Expanded="false">
+  <MudNavLink Href="/tools/rules-search" Icon="Icons.Material.Filled.Search">Rules Search</MudNavLink>
+  <MudNavLink Href="/tools/conversation-search" Icon="Icons.Material.Filled.Chat">Conversation Search</MudNavLink>
+  <MudNavLink Href="/tools/player-sentiment" Icon="Icons.Material.Filled.SentimentSatisfied">Player Sentiment</MudNavLink>
+  <MudNavLink Href="/tools/player-info" Icon="Icons.Material.Filled.Person">Player Info</MudNavLink>
+ </MudNavGroup>
  <MudNavGroup Title="Admin" Icon="Icons.Material.Filled.AdminPanelSettings" Expanded="false">
   <MudNavLink Href="/admin" Match="NavLinkMatch.All" Icon="Icons.Material.Filled.Dashboard">Admin Dashboard</MudNavLink>
   <MudNavLink Href="/rulesets" Icon="Icons.Material.Filled.Rule">Rulesets</MudNavLink>
   <MudNavLink Href="/agents" Icon="Icons.Material.Filled.SmartToy">Agents</MudNavLink>
-  <MudNavLink Href="/admin/rules-search-test" Icon="Icons.Material.Filled.Search">Rules Search Test</MudNavLink>
-  <MudNavLink Href="/admin/conversation-search-test" Icon="Icons.Material.Filled.Chat">Conversation Search Test</MudNavLink>
  </MudNavGroup>
 </MudNavMenu>

--- a/JAIMES AF.Web/Components/Pages/ConversationSearchTest.razor
+++ b/JAIMES AF.Web/Components/Pages/ConversationSearchTest.razor
@@ -1,4 +1,4 @@
-@page "/admin/conversation-search-test"
+@page "/tools/conversation-search"
 @rendermode InteractiveServer
 
 <PageTitle>Conversation Search Test</PageTitle>
@@ -75,7 +75,15 @@
 		{
 			<MudDivider Class="my-6"/>
 
-			<MudText Typo="Typo.h5" GutterBottom="true" Class="mb-4">Search Results (@_searchResult.Results.Length)
+			<MudText Typo="Typo.h5" GutterBottom="true" Class="mb-4">Tool Output</MudText>
+			<MudText Typo="Typo.body2" Class="mb-4 text-muted">This is the formatted output that the ConversationSearchTool returns to AI agents:</MudText>
+			<MudPaper Class="pa-4 mb-6" Elevation="1">
+				<MudText Typo="Typo.body1" Style="white-space: pre-wrap; font-family: monospace;">@_toolOutput</MudText>
+			</MudPaper>
+
+			<MudDivider Class="my-6"/>
+
+			<MudText Typo="Typo.h5" GutterBottom="true" Class="mb-4">Detailed Search Results (@_searchResult.Results.Length)
 			</MudText>
 
 			@if (_searchResult.Results.Length > 0)

--- a/JAIMES AF.Web/Components/Pages/PlayerInfoTest.razor
+++ b/JAIMES AF.Web/Components/Pages/PlayerInfoTest.razor
@@ -1,0 +1,67 @@
+@page "/tools/player-info"
+@rendermode InteractiveServer
+
+<PageTitle>Player Info Test</PageTitle>
+
+<MudContainer MaxWidth="MaxWidth.ExtraLarge" Class="pa-4">
+	<MudPaper Class="pa-8" Elevation="2">
+		<MudText Typo="Typo.h3" GutterBottom="true" Class="mb-2">Player Info Test</MudText>
+		<MudText Typo="Typo.subtitle1" GutterBottom="true" Class="mb-6 text-muted">Test the PlayerInfoTool functionality
+		</MudText>
+
+		<MudText Typo="Typo.body1" Class="mb-6" Style="line-height: 1.75;">
+			Use this tool to test the player info functionality. Select a game to view the player information that would be
+			returned by the PlayerInfoTool.
+		</MudText>
+
+		<MudDivider Class="my-6"/>
+
+		<MudPaper Class="pa-4" Elevation="1">
+			<MudText Typo="Typo.h6" GutterBottom="true" Class="mb-4">Game Selection</MudText>
+
+			<MudForm>
+				<MudSelect @bind-Value="_selectedGameId"
+				           Label="Game"
+				           Variant="Variant.Outlined"
+				           Class="mb-4"
+				           FullWidth="true"
+				           HelperText="Select a game to view player information">
+					<MudSelectItem Value="@((Guid?) null)">Select a game...</MudSelectItem>
+					@foreach (GameInfoResponse game in _games)
+					{
+						<MudSelectItem Value="@((Guid?) game.GameId)">@FormatGameDisplay(game)</MudSelectItem>
+					}
+				</MudSelect>
+
+				<MudButton Variant="Variant.Filled"
+				           Color="Color.Primary"
+				           OnClick="GetPlayerInfoAsync"
+				           Disabled="@(_isLoading || !_selectedGameId.HasValue)"
+				           Class="mb-4">
+					@if (_isLoading)
+					{
+						<MudProgressCircular Size="Size.Small" Indeterminate="true" Class="me-2"/>
+					}
+					Get Player Info
+				</MudButton>
+			</MudForm>
+		</MudPaper>
+
+		@if (!string.IsNullOrEmpty(_errorMessage))
+		{
+			<MudAlert Severity="Severity.Error" Class="mt-4">@_errorMessage</MudAlert>
+		}
+
+		@if (!string.IsNullOrEmpty(_toolOutput))
+		{
+			<MudDivider Class="my-6"/>
+
+			<MudText Typo="Typo.h5" GutterBottom="true" Class="mb-4">Tool Output</MudText>
+			<MudText Typo="Typo.body2" Class="mb-4 text-muted">This is the formatted output that the PlayerInfoTool returns to AI agents:</MudText>
+			<MudPaper Class="pa-4 mb-6" Elevation="1">
+				<MudText Typo="Typo.body1" Style="white-space: pre-wrap; font-family: monospace;">@_toolOutput</MudText>
+			</MudPaper>
+		}
+	</MudPaper>
+</MudContainer>
+

--- a/JAIMES AF.Web/Components/Pages/PlayerInfoTest.razor.cs
+++ b/JAIMES AF.Web/Components/Pages/PlayerInfoTest.razor.cs
@@ -1,0 +1,97 @@
+using MattEland.Jaimes.ServiceDefinitions.Responses;
+
+namespace MattEland.Jaimes.Web.Components.Pages;
+
+public partial class PlayerInfoTest
+{
+	[Inject] public HttpClient Http { get; set; } = null!;
+
+	[Inject] public ILoggerFactory LoggerFactory { get; set; } = null!;
+
+	private GameInfoResponse[] _games = [];
+	private Guid? _selectedGameId;
+	private bool _isLoading = false;
+	private string? _errorMessage;
+	private string? _toolOutput;
+
+	protected override async Task OnInitializedAsync()
+	{
+		await LoadGamesAsync();
+	}
+
+	private async Task LoadGamesAsync()
+	{
+		try
+		{
+			ListGamesResponse? response = await Http.GetFromJsonAsync<ListGamesResponse>("/games");
+			_games = response?.Games ?? [];
+		}
+		catch (Exception ex)
+		{
+			LoggerFactory.CreateLogger("PlayerInfoTest").LogError(ex, "Failed to load games from API");
+			_errorMessage = "Failed to load games: " + ex.Message;
+		}
+	}
+
+	private async Task GetPlayerInfoAsync()
+	{
+		if (!_selectedGameId.HasValue)
+		{
+			_errorMessage = "Please select a game.";
+			return;
+		}
+
+		_isLoading = true;
+		_errorMessage = null;
+		_toolOutput = null;
+
+		try
+		{
+			// Get the game state which includes player information
+			GameStateResponse? gameState = await Http.GetFromJsonAsync<GameStateResponse>($"/games/{_selectedGameId.Value}");
+
+			if (gameState == null)
+			{
+				_errorMessage = "Game not found.";
+				return;
+			}
+
+			// Get player details to include description
+			PlayerResponse? playerResponse = null;
+			try
+			{
+				playerResponse = await Http.GetFromJsonAsync<PlayerResponse>($"/players/{gameState.PlayerId}");
+			}
+			catch
+			{
+				// Player endpoint might fail, but we can still show basic info
+			}
+
+			// Format as the tool would
+			string info = $"Player Name: {gameState.PlayerName}\nPlayer ID: {gameState.PlayerId}";
+
+			if (playerResponse != null && !string.IsNullOrWhiteSpace(playerResponse.Description))
+			{
+				info += $"\nPlayer Description: {playerResponse.Description}";
+			}
+
+			_toolOutput = info;
+		}
+		catch (Exception ex)
+		{
+			LoggerFactory.CreateLogger("PlayerInfoTest").LogError(ex, "Failed to get player info");
+			_errorMessage = "Failed to get player info: " + ex.Message;
+		}
+		finally
+		{
+			_isLoading = false;
+			StateHasChanged();
+		}
+	}
+
+	private string FormatGameDisplay(GameInfoResponse game)
+	{
+		return $"{game.PlayerName} - {game.ScenarioName} ({game.RulesetName})";
+	}
+}
+

--- a/JAIMES AF.Web/Components/Pages/PlayerSentimentTest.razor
+++ b/JAIMES AF.Web/Components/Pages/PlayerSentimentTest.razor
@@ -1,0 +1,67 @@
+@page "/tools/player-sentiment"
+@rendermode InteractiveServer
+
+<PageTitle>Player Sentiment Test</PageTitle>
+
+<MudContainer MaxWidth="MaxWidth.ExtraLarge" Class="pa-4">
+	<MudPaper Class="pa-8" Elevation="2">
+		<MudText Typo="Typo.h3" GutterBottom="true" Class="mb-2">Player Sentiment Test</MudText>
+		<MudText Typo="Typo.subtitle1" GutterBottom="true" Class="mb-6 text-muted">Test the PlayerSentimentTool functionality
+		</MudText>
+
+		<MudText Typo="Typo.body1" Class="mb-6" Style="line-height: 1.75;">
+			Use this tool to test the player sentiment analysis functionality. Select a game to view the most recent sentiment
+			analysis results for the player in that game.
+		</MudText>
+
+		<MudDivider Class="my-6"/>
+
+		<MudPaper Class="pa-4" Elevation="1">
+			<MudText Typo="Typo.h6" GutterBottom="true" Class="mb-4">Game Selection</MudText>
+
+			<MudForm>
+				<MudSelect @bind-Value="_selectedGameId"
+				           Label="Game"
+				           Variant="Variant.Outlined"
+				           Class="mb-4"
+				           FullWidth="true"
+				           HelperText="Select a game to view player sentiment">
+					<MudSelectItem Value="@((Guid?) null)">Select a game...</MudSelectItem>
+					@foreach (GameInfoResponse game in _games)
+					{
+						<MudSelectItem Value="@((Guid?) game.GameId)">@FormatGameDisplay(game)</MudSelectItem>
+					}
+				</MudSelect>
+
+				<MudButton Variant="Variant.Filled"
+				           Color="Color.Primary"
+				           OnClick="GetSentimentAsync"
+				           Disabled="@(_isLoading || !_selectedGameId.HasValue)"
+				           Class="mb-4">
+					@if (_isLoading)
+					{
+						<MudProgressCircular Size="Size.Small" Indeterminate="true" Class="me-2"/>
+					}
+					Get Sentiment
+				</MudButton>
+			</MudForm>
+		</MudPaper>
+
+		@if (!string.IsNullOrEmpty(_errorMessage))
+		{
+			<MudAlert Severity="Severity.Error" Class="mt-4">@_errorMessage</MudAlert>
+		}
+
+		@if (!string.IsNullOrEmpty(_toolOutput))
+		{
+			<MudDivider Class="my-6"/>
+
+			<MudText Typo="Typo.h5" GutterBottom="true" Class="mb-4">Tool Output</MudText>
+			<MudText Typo="Typo.body2" Class="mb-4 text-muted">This is the formatted output that the PlayerSentimentTool returns to AI agents:</MudText>
+			<MudPaper Class="pa-4 mb-6" Elevation="1">
+				<MudText Typo="Typo.body1" Style="white-space: pre-wrap; font-family: monospace;">@_toolOutput</MudText>
+			</MudPaper>
+		}
+	</MudPaper>
+</MudContainer>
+

--- a/JAIMES AF.Web/Components/Pages/PlayerSentimentTest.razor.cs
+++ b/JAIMES AF.Web/Components/Pages/PlayerSentimentTest.razor.cs
@@ -1,0 +1,126 @@
+using MattEland.Jaimes.ServiceDefinitions.Responses;
+
+namespace MattEland.Jaimes.Web.Components.Pages;
+
+public partial class PlayerSentimentTest
+{
+	[Inject] public HttpClient Http { get; set; } = null!;
+
+	[Inject] public ILoggerFactory LoggerFactory { get; set; } = null!;
+
+	private GameInfoResponse[] _games = [];
+	private Guid? _selectedGameId;
+	private bool _isLoading = false;
+	private string? _errorMessage;
+	private string? _toolOutput;
+
+	protected override async Task OnInitializedAsync()
+	{
+		await LoadGamesAsync();
+	}
+
+	private async Task LoadGamesAsync()
+	{
+		try
+		{
+			ListGamesResponse? response = await Http.GetFromJsonAsync<ListGamesResponse>("/games");
+			_games = response?.Games ?? [];
+		}
+		catch (Exception ex)
+		{
+			LoggerFactory.CreateLogger("PlayerSentimentTest").LogError(ex, "Failed to load games from API");
+			_errorMessage = "Failed to load games: " + ex.Message;
+		}
+	}
+
+	private async Task GetSentimentAsync()
+	{
+		if (!_selectedGameId.HasValue)
+		{
+			_errorMessage = "Please select a game.";
+			return;
+		}
+
+		_isLoading = true;
+		_errorMessage = null;
+		_toolOutput = null;
+
+		try
+		{
+			// Get the game state which includes messages
+			GameStateResponse? gameState = await Http.GetFromJsonAsync<GameStateResponse>($"/games/{_selectedGameId.Value}");
+
+			if (gameState == null)
+			{
+				_errorMessage = "Game not found.";
+				return;
+			}
+
+			// Filter messages with sentiment for the current game and player
+			// Order by CreatedAt descending and take the last 5
+			MessageResponse[] messagesWithSentiment = gameState.Messages
+				.Where(m => m.Sentiment != null)
+				.OrderByDescending(m => m.CreatedAt)
+				.Take(5)
+				.ToArray();
+
+			if (messagesWithSentiment.Length == 0)
+			{
+				_toolOutput = "No sentiment analysis results available for this player in the current game.";
+				return;
+			}
+
+			// Calculate average sentiment
+			double averageSentiment = messagesWithSentiment.Average(m => m.Sentiment!.Value);
+			string averageLabel = averageSentiment switch
+			{
+				> 0.33 => "Positive",
+				< -0.33 => "Negative",
+				_ => "Neutral"
+			};
+
+			// Format results as the tool would
+			List<string> resultTexts = new();
+			
+			// Add average sentiment at the beginning
+			resultTexts.Add($"Average Sentiment: {averageLabel} ({averageSentiment:F2})");
+			resultTexts.Add(string.Empty); // Empty line separator
+			
+			foreach (MessageResponse message in messagesWithSentiment)
+			{
+				string sentimentLabel = message.Sentiment switch
+				{
+					1 => "Positive",
+					-1 => "Negative",
+					0 => "Neutral",
+					_ => "Unknown"
+				};
+
+				string messagePreview = message.Text.Length > 100
+					? message.Text.Substring(0, 100) + "..."
+					: message.Text;
+
+				resultTexts.Add(
+					$"[{message.CreatedAt:yyyy-MM-dd HH:mm:ss}] {sentimentLabel} ({message.Sentiment}): {messagePreview}");
+			}
+
+			_toolOutput = string.Join("\n", resultTexts);
+		}
+		catch (Exception ex)
+		{
+			LoggerFactory.CreateLogger("PlayerSentimentTest").LogError(ex, "Failed to get sentiment");
+			_errorMessage = "Failed to get sentiment: " + ex.Message;
+		}
+		finally
+		{
+			_isLoading = false;
+			StateHasChanged();
+		}
+	}
+
+	private string FormatGameDisplay(GameInfoResponse game)
+	{
+		return $"{game.PlayerName} - {game.ScenarioName} ({game.RulesetName})";
+	}
+}
+

--- a/JAIMES AF.Web/Components/Pages/RulesSearchTest.razor
+++ b/JAIMES AF.Web/Components/Pages/RulesSearchTest.razor
@@ -1,4 +1,4 @@
-@page "/admin/rules-search-test"
+@page "/tools/rules-search"
 @rendermode InteractiveServer
 
 <PageTitle>Rules Search Test</PageTitle>
@@ -75,7 +75,15 @@
 		{
 			<MudDivider Class="my-6"/>
 
-			<MudText Typo="Typo.h5" GutterBottom="true" Class="mb-4">Search Results (@_searchResult.Results.Length)
+			<MudText Typo="Typo.h5" GutterBottom="true" Class="mb-4">Tool Output</MudText>
+			<MudText Typo="Typo.body2" Class="mb-4 text-muted">This is the formatted output that the RulesSearchTool returns to AI agents:</MudText>
+			<MudPaper Class="pa-4 mb-6" Elevation="1">
+				<MudText Typo="Typo.body1" Style="white-space: pre-wrap; font-family: monospace;">@_toolOutput</MudText>
+			</MudPaper>
+
+			<MudDivider Class="my-6"/>
+
+			<MudText Typo="Typo.h5" GutterBottom="true" Class="mb-4">Detailed Search Results (@_searchResult.Results.Length)
 			</MudText>
 
 			@if (_searchResult.Results.Length > 0)

--- a/JAIMES AF.Web/Components/Pages/RulesSearchTest.razor.cs
+++ b/JAIMES AF.Web/Components/Pages/RulesSearchTest.razor.cs
@@ -13,6 +13,7 @@ public partial class RulesSearchTest
     private bool _isSearching = false;
     private string? _errorMessage;
     private SearchRulesResponse? _searchResult;
+    private string? _toolOutput;
 
     protected override async Task OnInitializedAsync()
     {
@@ -64,6 +65,17 @@ public partial class RulesSearchTest
             if (response.IsSuccessStatusCode)
             {
                 _searchResult = await response.Content.ReadFromJsonAsync<SearchRulesResponse>();
+                
+                // Format the output as the tool would return it
+                if (_searchResult != null && _searchResult.Results.Length > 0)
+                {
+                    List<string> resultTexts = _searchResult.Results.Select(r => r.Text).ToList();
+                    _toolOutput = string.Join("\n\n---\n\n", resultTexts);
+                }
+                else
+                {
+                    _toolOutput = "No relevant rules found for your query.";
+                }
             }
             else
             {


### PR DESCRIPTION
- Introduced a new Sentiment property in MessageDto and MessageResponse to facilitate sentiment analysis.
- Updated MessageMapper and MessageResponseMapper to include mapping for the new Sentiment property.
- Enhanced PlayerSentimentTool to calculate and display average sentiment for messages, improving sentiment analysis output.
- Refactored ConversationSearchTest and RulesSearchTest pages to update routing and output formatting for better user experience.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Feature: Sentiment surfaced end-to-end and tool testing UX**
> 
> - Add `Sentiment` to `MessageDto` and `MessageResponse`; update mapping (`MessageMapper`, `MessageResponseMapper`) to include `Sentiment`
> - Enhance `PlayerSentimentTool` to compute and display average sentiment and formatted recent results
> - Introduce a "Tools" nav group in `NavMenu.razor` and move routes to `/tools/*`
> - Add new test pages `PlayerInfoTest` and `PlayerSentimentTest` under `/tools`, and update `RulesSearchTest` and `ConversationSearchTest` to display AI-facing, tool-formatted output alongside detailed results
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d67b13c204525bd0c561daaf966987073cc59a88. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->