### PR TITLE
JAF-74: Add StorytellerEvaluator and associated tests

### DIFF
--- a/JAIMES AF.ApiService/Endpoints/ListAvailableEvaluatorsEndpoint.cs
+++ b/JAIMES AF.ApiService/Endpoints/ListAvailableEvaluatorsEndpoint.cs
@@ -1,0 +1,37 @@
+using MattEland.Jaimes.ServiceDefinitions.Responses;
+using Microsoft.Extensions.AI.Evaluation;
+
+namespace MattEland.Jaimes.ApiService.Endpoints;
+
+/// <summary>
+/// Endpoint for listing available evaluator names for use in the test evaluator UI.
+/// </summary>
+public class ListAvailableEvaluatorsEndpoint : EndpointWithoutRequest<AvailableEvaluatorsResponse>
+{
+    public required IEnumerable<IEvaluator> Evaluators { get; set; }
+
+    public override void Configure()
+    {
+        Get("/admin/evaluators/available");
+        AllowAnonymous();
+        Description(b => b
+            .Produces<AvailableEvaluatorsResponse>(StatusCodes.Status200OK)
+            .WithTags("Evaluators"));
+    }
+
+    public override Task HandleAsync(CancellationToken ct)
+    {
+        List<string> evaluatorNames = Evaluators
+            .Select(e => e.GetType().Name)
+            .Distinct()
+            .OrderBy(n => n)
+            .ToList();
+
+        AvailableEvaluatorsResponse response = new()
+        {
+            EvaluatorNames = evaluatorNames
+        };
+
+        return Send.OkAsync(response, ct);
+    }
+}

--- a/JAIMES AF.Evaluators/EvaluationParseResult.cs
+++ b/JAIMES AF.Evaluators/EvaluationParseResult.cs
@@ -1,0 +1,15 @@
+namespace MattEland.Jaimes.Evaluators;
+
+/// <summary>
+/// Represents the parsed result from an LLM-based evaluation response.
+/// Extracts structured data from the S0, S1, and S2 tags.
+/// </summary>
+/// <param name="Score">The numeric score (1-5) extracted from the S2 tag.</param>
+/// <param name="ThoughtChain">The reasoning chain extracted from the S0 tag.</param>
+/// <param name="Explanation">The explanation extracted from the S1 tag.</param>
+/// <param name="ParseSuccess">Whether the response was successfully parsed.</param>
+public record EvaluationParseResult(
+    int Score,
+    string ThoughtChain,
+    string Explanation,
+    bool ParseSuccess);

--- a/JAIMES AF.Evaluators/LlmBasedEvaluator.cs
+++ b/JAIMES AF.Evaluators/LlmBasedEvaluator.cs
@@ -1,0 +1,187 @@
+using System.Text.RegularExpressions;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.AI.Evaluation;
+
+namespace MattEland.Jaimes.Evaluators;
+
+/// <summary>
+/// Abstract base class for evaluators that use an IChatClient to generate evaluation scores.
+/// Provides common functionality for response parsing, metric creation, and LLM request execution.
+/// </summary>
+/// <param name="chatClient">The chat client to use for evaluation.</param>
+public abstract class LlmBasedEvaluator(IChatClient chatClient) : IEvaluator
+{
+    /// <summary>
+    /// Gets the chat client used for evaluation.
+    /// </summary>
+    protected IChatClient ChatClient { get; } = chatClient;
+
+    /// <summary>
+    /// Gets the name of the metric this evaluator produces.
+    /// </summary>
+    public abstract string EvaluatorMetricName { get; }
+
+    /// <inheritdoc />
+    public IReadOnlyCollection<string> EvaluationMetricNames => [EvaluatorMetricName];
+
+    /// <inheritdoc />
+    public abstract ValueTask<EvaluationResult> EvaluateAsync(
+        IEnumerable<ChatMessage> messages,
+        ChatResponse modelResponse,
+        ChatConfiguration? chatConfiguration = null,
+        IEnumerable<EvaluationContext>? evaluationContext = null,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Extracts the system prompt and conversation messages from a list of chat messages.
+    /// </summary>
+    /// <param name="messages">The messages to extract from.</param>
+    /// <returns>A tuple containing the system prompt (if any) and the list of non-system messages.</returns>
+    protected static (string? SystemPrompt, List<ChatMessage> ConversationMessages) ExtractMessages(
+        IEnumerable<ChatMessage> messages)
+    {
+        List<ChatMessage> messagesList = messages.ToList();
+        string? systemPrompt = messagesList.FirstOrDefault(m => m.Role == ChatRole.System)?.Text;
+        List<ChatMessage> conversationMessages = messagesList
+            .Where(m => m.Role != ChatRole.System)
+            .ToList();
+
+        return (systemPrompt, conversationMessages);
+    }
+
+    /// <summary>
+    /// Executes an LLM evaluation request with no tools enabled.
+    /// </summary>
+    /// <param name="prompt">The evaluation prompt to send.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The response text from the LLM.</returns>
+    protected async Task<string> GetEvaluationResponseAsync(string prompt, CancellationToken cancellationToken)
+    {
+        ChatOptions chatOptions = new()
+        {
+            Tools = [] // Ensure no tools are used
+        };
+
+        var requestMessages = new List<ChatMessage>
+        {
+            new(ChatRole.User, prompt)
+        };
+
+        ChatResponse response = await ChatClient.GetResponseAsync(requestMessages, chatOptions, cancellationToken);
+        return response.Text ?? string.Empty;
+    }
+
+    /// <summary>
+    /// Parses an evaluation response to extract the S0 (ThoughtChain), S1 (Explanation), and S2 (Score) tags.
+    /// </summary>
+    /// <param name="responseText">The response text from the LLM.</param>
+    /// <returns>An <see cref="EvaluationParseResult"/> containing the parsed data.</returns>
+    protected static EvaluationParseResult ParseEvaluationResponse(string? responseText)
+    {
+        int score = 1;
+        string thoughtChain = string.Empty;
+        string explanation = "Failed to parse evaluation response.";
+        bool parseSuccess = false;
+
+        if (!string.IsNullOrWhiteSpace(responseText))
+        {
+            const RegexOptions regexOptions = RegexOptions.Singleline | RegexOptions.IgnoreCase | RegexOptions.ExplicitCapture;
+            TimeSpan regexTimeout = TimeSpan.FromSeconds(1);
+
+            try
+            {
+                // Extract S0 (ThoughtChain)
+                Match s0Match = Regex.Match(responseText, @"<S0>(?<content>.*?)</S0>", regexOptions, regexTimeout);
+                if (s0Match.Success)
+                {
+                    thoughtChain = s0Match.Groups["content"].Value.Trim();
+                }
+
+                // Extract S1 (Explanation)
+                Match s1Match = Regex.Match(responseText, @"<S1>(?<content>.*?)</S1>", regexOptions, regexTimeout);
+                if (s1Match.Success)
+                {
+                    explanation = s1Match.Groups["content"].Value.Trim();
+                }
+
+                // Extract S2 (Score)
+                Match s2Match = Regex.Match(responseText, @"<S2>(?<content>.*?)</S2>", regexOptions, regexTimeout);
+                if (s2Match.Success)
+                {
+                    string scoreText = s2Match.Groups["content"].Value.Trim();
+                    if (int.TryParse(scoreText, out int parsedScore))
+                    {
+                        score = parsedScore;
+                        parseSuccess = true;
+                    }
+                }
+            }
+            catch (RegexMatchTimeoutException)
+            {
+                explanation = "Regex parsing timed out. Response may be malformed.";
+            }
+        }
+
+        // Ensure score is within range
+        score = Math.Clamp(score, 1, 5);
+
+        return new EvaluationParseResult(score, thoughtChain, explanation, parseSuccess);
+    }
+
+    /// <summary>
+    /// Creates a <see cref="NumericMetric"/> from an evaluation parse result with standard diagnostics.
+    /// </summary>
+    /// <param name="parseResult">The parsed evaluation result.</param>
+    /// <param name="rawResponseText">The raw response text for diagnostic purposes if parsing failed.</param>
+    /// <returns>A <see cref="NumericMetric"/> with the score, explanation, and diagnostics.</returns>
+    protected NumericMetric CreateMetric(EvaluationParseResult parseResult, string? rawResponseText = null)
+    {
+        // Determine pass/fail (fail on 3 or below, pass on 4 or 5)
+        bool passed = parseResult.Score >= 4;
+        string passFailStatus = passed ? "Pass" : "Fail";
+
+        NumericMetric metric = new(EvaluatorMetricName)
+        {
+            Value = parseResult.Score,
+            Reason = parseResult.Explanation
+        };
+
+        // Add comprehensive diagnostics
+        metric.Diagnostics ??= [];
+
+        if (parseResult.ParseSuccess)
+        {
+            metric.Diagnostics.Add(new EvaluationDiagnostic(
+                EvaluationDiagnosticSeverity.Informational,
+                $"{EvaluatorMetricName} Score: {parseResult.Score} ({passFailStatus})"));
+
+            if (!string.IsNullOrWhiteSpace(parseResult.ThoughtChain))
+            {
+                metric.Diagnostics.Add(new EvaluationDiagnostic(
+                    EvaluationDiagnosticSeverity.Informational,
+                    $"ThoughtChain: {parseResult.ThoughtChain}"));
+            }
+        }
+        else
+        {
+            string displayText = string.IsNullOrWhiteSpace(rawResponseText) ? "{Empty}" : rawResponseText;
+            int length = Math.Min(200, displayText.Length);
+
+            metric.Diagnostics.Add(new EvaluationDiagnostic(
+                EvaluationDiagnosticSeverity.Warning,
+                $"Failed to parse evaluation response. Raw response: {displayText[..length]}"));
+        }
+
+        return metric;
+    }
+
+    /// <summary>
+    /// Builds a simple conversation history string from a list of messages.
+    /// </summary>
+    /// <param name="conversationMessages">The conversation messages (excluding system prompt).</param>
+    /// <returns>A formatted string with role and text for each message.</returns>
+    protected static string BuildSimpleConversationHistory(List<ChatMessage> conversationMessages)
+    {
+        return string.Join("\n", conversationMessages.Select(m => $"{m.Role}: {m.Text}"));
+    }
+}

--- a/JAIMES AF.Evaluators/StorytellerEvaluator.cs
+++ b/JAIMES AF.Evaluators/StorytellerEvaluator.cs
@@ -1,0 +1,226 @@
+using System.ComponentModel;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.AI.Evaluation;
+
+namespace MattEland.Jaimes.Evaluators;
+
+/// <summary>
+/// An evaluator that scores a conversation based on how well the AI game master maintains narrative engagement,
+/// guides the story forward, and keeps the experience compelling. This evaluator analyzes trends over recent
+/// interactions rather than just the final response.
+/// </summary>
+/// <param name="chatClient">The chat client to use for evaluation.</param>
+[Description("Evaluates assistant responses for narrative engagement, pacing, tension, and storytelling quality across recent interactions.")]
+public class StorytellerEvaluator(IChatClient chatClient) : LlmBasedEvaluator(chatClient)
+{
+    /// <summary>
+    /// The name of the metric produced by this evaluator.
+    /// </summary>
+    public const string MetricName = "Storyteller";
+
+    private const int TargetExchangeCount = 5;
+    private const int MinimumExchangeWarningThreshold = 3;
+
+    /// <inheritdoc />
+    public override string EvaluatorMetricName => MetricName;
+
+    /// <inheritdoc />
+    public override async ValueTask<EvaluationResult> EvaluateAsync(
+        IEnumerable<ChatMessage> messages,
+        ChatResponse modelResponse,
+        ChatConfiguration? chatConfiguration = null,
+        IEnumerable<EvaluationContext>? evaluationContext = null,
+        CancellationToken cancellationToken = default)
+    {
+        // Extract system prompt and conversation messages
+        var (systemPrompt, conversationMessages) = ExtractMessages(messages);
+
+        // Extract the last N exchanges (user + assistant pairs) for trend analysis
+        List<(ChatMessage User, ChatMessage Assistant)> recentExchanges = ExtractRecentExchanges(conversationMessages, TargetExchangeCount);
+        int exchangeCount = recentExchanges.Count;
+
+        // Build conversation history text showing the exchanges
+        string conversationHistory = BuildConversationHistory(recentExchanges);
+
+        // Build the evaluation prompt
+        string prompt = BuildEvaluationPrompt(
+            modelResponse.Text ?? string.Empty,
+            conversationHistory,
+            systemPrompt,
+            exchangeCount);
+
+        string responseText = await GetEvaluationResponseAsync(prompt, cancellationToken);
+
+        // Parse the response
+        EvaluationParseResult parseResult = ParseEvaluationResponse(responseText);
+
+        // Create metric with standard diagnostics
+        NumericMetric metric = CreateMetric(parseResult, responseText);
+
+        // Add evaluator-specific diagnostics
+        if (parseResult.ParseSuccess)
+        {
+            metric.Diagnostics!.Add(new EvaluationDiagnostic(
+                EvaluationDiagnosticSeverity.Informational,
+                $"Exchanges analyzed: {exchangeCount}"));
+        }
+
+        // Add warning diagnostic if conversation is too short for reliable trend analysis
+        if (exchangeCount < MinimumExchangeWarningThreshold)
+        {
+            metric.Diagnostics!.Add(new EvaluationDiagnostic(
+                EvaluationDiagnosticSeverity.Warning,
+                $"Limited conversation context: Only {exchangeCount} exchange(s) available for trend analysis. Results may be less reliable."));
+        }
+
+        return new EvaluationResult(metric);
+    }
+
+    private static List<(ChatMessage User, ChatMessage Assistant)> ExtractRecentExchanges(
+        List<ChatMessage> conversationMessages,
+        int maxExchanges)
+    {
+        var exchanges = new List<(ChatMessage User, ChatMessage Assistant)>();
+
+        // Walk through messages and pair user messages with their following assistant responses
+        for (int i = 0; i < conversationMessages.Count - 1; i++)
+        {
+            if (conversationMessages[i].Role == ChatRole.User &&
+                conversationMessages[i + 1].Role == ChatRole.Assistant)
+            {
+                exchanges.Add((conversationMessages[i], conversationMessages[i + 1]));
+            }
+        }
+
+        // Take the most recent exchanges
+        return exchanges
+            .TakeLast(maxExchanges)
+            .ToList();
+    }
+
+    private static string BuildConversationHistory(List<(ChatMessage User, ChatMessage Assistant)> exchanges)
+    {
+        if (exchanges.Count == 0)
+        {
+            return "No conversation exchanges available.";
+        }
+
+        var parts = new List<string>();
+        int exchangeNumber = 1;
+
+        foreach (var (user, assistant) in exchanges)
+        {
+            parts.Add($"--- Exchange {exchangeNumber} ---");
+            parts.Add($"Player: {user.Text}");
+            parts.Add($"Game Master: {assistant.Text}");
+            exchangeNumber++;
+        }
+
+        return string.Join("\n", parts);
+    }
+
+    private static string BuildEvaluationPrompt(
+        string responseText,
+        string conversationHistory,
+        string? systemPrompt,
+        int exchangeCount)
+    {
+        string exchangeContext = exchangeCount switch
+        {
+            0 => "Note: No prior exchanges are available. Evaluate based on the current response only.",
+            1 => "Note: Only 1 exchange is available. Limited trend analysis is possible.",
+            < 3 => $"Note: Only {exchangeCount} exchanges are available. Trend analysis is limited.",
+            _ => $"Analyzing the last {exchangeCount} exchanges for narrative trends."
+        };
+
+        return $"""
+            You are an expert in evaluating the quality of storytelling from an AI Game Master in a solo role-playing game. Your goal is to assess how well the Game Master maintains narrative engagement, guides the story forward, and keeps the experience compelling for the player.
+
+            IMPORTANT: You are evaluating TRENDS across the conversation, not just the final response. Consider how the narrative has developed over the recent exchanges.
+
+            Definition: You are given a definition of storytelling quality criteria to guide your evaluation.
+            Data: Your input data includes the recent conversation exchanges between the player and Game Master.
+            Tasks: Evaluate the overall storytelling quality based on the conversation trends.
+
+            {exchangeContext}
+
+            Definition
+            Storytelling Quality refers to the AI Game Master's ability to maintain narrative engagement, create meaningful tension, guide the story at an appropriate pace, and provide the player with compelling hooks to pursue. A skilled Game Master balances challenge with fairness, moves the story forward without rushing, and gives players clear opportunities to focus on elements they find interesting.
+
+            Evaluation Criteria
+            Consider these aspects when evaluating storytelling quality:
+
+            1. NARRATIVE MOMENTUM: Does the story progress meaningfully? Are there clear developments, revelations, or consequences that move the narrative forward? A stalling narrative that goes nowhere loses player interest.
+
+            2. TENSION & CHALLENGE: Are there meaningful stakes that engage the player? Good storytelling includes obstacles, conflicts, and challenges that make success feel earned. However, challenges should be fair and surmountable.
+
+            3. FAIRNESS: Is the player given reasonable opportunities to succeed? Does the GM acknowledge player actions and give them meaningful impact? Unfair scenarios where the player has no real chance to succeed are frustrating.
+
+            4. PACING: Is the narrative moving at an appropriate speed? Rushing through content doesn't give players time to engage with what interests them. Dragging creates boredom. Good pacing lets players savor important moments while maintaining forward momentum.
+
+            5. FOCUS OPPORTUNITIES: Does the player have clear hooks and options to pursue? Good storytelling presents interesting threads, characters, mysteries, or goals that invite player investment without dictating what they must do.
+
+            Ratings
+            [Storyteller: 1] (Disengaging Narrative)
+            Definition: The storytelling fails to engage the player. The narrative is stagnant with no meaningful progression, there are no stakes or tension, the GM is unfair to the player, pacing is severely off (either nothing happens or events rush by without player input), and there are no clear hooks for player interest.
+
+            Examples:
+            - Multiple exchanges where nothing meaningful happens
+            - The player's actions have no consequences or are ignored
+            - Overwhelming the player with rapid-fire events they cannot respond to
+            - Situations that are clearly unwinnable or punishingly unfair
+
+            [Storyteller: 2] (Weak Narrative)
+            Definition: The storytelling has significant issues. There may be some narrative progression but it feels forced or uninteresting. Tension is minimal or artificially inflated. The pacing has notable problems. The player has few meaningful options to pursue.
+
+            Examples:
+            - Story progression that feels disconnected from player actions
+            - Stakes that feel arbitrary or unearned
+            - Long stretches of description with little happening
+            - Limited player agency in shaping the narrative direction
+
+            [Storyteller: 3] (Adequate Narrative)
+            Definition: The storytelling is functional but unremarkable. The story moves forward but without strong hooks. There is some tension but it doesn't fully engage. Pacing is acceptable but may drag or rush at times. The player has options but they may not feel compelling.
+
+            Examples:
+            - Competent but predictable story progression
+            - Some challenge present but stakes feel low
+            - Adequate but uninspiring descriptions and events
+            - Options exist but don't strongly invite investment
+
+            [Storyteller: 4] (Engaging Narrative)
+            Definition: The storytelling is good with engaging elements. The narrative progresses with interesting developments. There is meaningful tension and challenge while remaining fair. Pacing is generally appropriate. The player has clear and interesting hooks to pursue.
+
+            Examples:
+            - Story developments that feel consequential and connected to player actions
+            - Challenges that are engaging without being unfair
+            - Good balance of action, description, and player opportunity
+            - Multiple interesting threads for the player to follow
+
+            [Storyteller: 5] (Compelling Narrative)
+            Definition: The storytelling is excellent and highly engaging. The narrative has strong forward momentum with exciting developments. Tension and stakes feel real and meaningful while giving the player fair chances. Pacing is excellent, giving weight to important moments without dragging. The player has multiple compelling hooks that invite deep investment.
+
+            Examples:
+            - Narrative developments that create genuine excitement or intrigue
+            - Challenges that feel earned and satisfying to overcome
+            - Perfect pacing that matches the story's emotional beats
+            - Rich world and character hooks that make the player want to explore more
+
+            Data
+            MOST RECENT RESPONSE: [Game Master] {responseText}
+
+            RECENT CONVERSATION EXCHANGES:
+            {conversationHistory}
+
+            {(string.IsNullOrWhiteSpace(systemPrompt) ? "" : $"\nSystem Instructions for the Game Master:\n{systemPrompt}")}
+
+            Tasks
+            Please provide your assessment Score based on the storytelling quality observed across the conversation exchanges. Your output should include the following information:
+            ThoughtChain: To improve the reasoning process, think step by step and include a step-by-step explanation of your thought process as you analyze the conversation trends based on the definitions. Consider narrative momentum, tension, fairness, pacing, and focus opportunities across all exchanges. Keep it brief and start your ThoughtChain with "Let's think step by step:".
+            Explanation: a very short explanation of why you think the conversation should get that Score.
+            Score: based on your previous analysis, provide your Score. The Score you give MUST be an integer score (i.e., "1", "2"...) based on the levels of the definitions.
+            Please provide your answers between the tags: <S0>your chain of thoughts</S0>, <S1>your explanation</S1>, <S2>your Score</S2>.
+            Output
+            """;
+    }
+}

--- a/JAIMES AF.ServiceDefinitions/Responses/AvailableEvaluatorsResponse.cs
+++ b/JAIMES AF.ServiceDefinitions/Responses/AvailableEvaluatorsResponse.cs
@@ -1,0 +1,13 @@
+namespace MattEland.Jaimes.ServiceDefinitions.Responses;
+
+/// <summary>
+/// Response containing the list of available evaluator names.
+/// These are dynamically discovered from registered IEvaluator implementations.
+/// </summary>
+public class AvailableEvaluatorsResponse
+{
+    /// <summary>
+    /// Gets or sets the list of available evaluator names.
+    /// </summary>
+    public List<string> EvaluatorNames { get; set; } = [];
+}

--- a/JAIMES AF.Tests/Endpoints/ListAvailableEvaluatorsEndpointTests.cs
+++ b/JAIMES AF.Tests/Endpoints/ListAvailableEvaluatorsEndpointTests.cs
@@ -1,0 +1,63 @@
+using System.Net;
+using System.Net.Http.Json;
+using MattEland.Jaimes.ServiceDefinitions.Responses;
+
+namespace MattEland.Jaimes.Tests.Endpoints;
+
+public class ListAvailableEvaluatorsEndpointTests : EndpointTestBase
+{
+    [Fact]
+    public async Task ListAvailableEvaluators_ReturnsRegisteredEvaluators()
+    {
+        CancellationToken ct = TestContext.Current.CancellationToken;
+
+        // Call the endpoint
+        var httpResponse = await Client.GetAsync("/admin/evaluators/available", ct);
+        httpResponse.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        var response = await httpResponse.Content.ReadFromJsonAsync<AvailableEvaluatorsResponse>(ct);
+
+        // Verify response structure
+        response.ShouldNotBeNull();
+        response.EvaluatorNames.ShouldNotBeNull();
+        response.EvaluatorNames.ShouldNotBeEmpty();
+    }
+
+    [Fact]
+    public async Task ListAvailableEvaluators_IncludesExpectedEvaluators()
+    {
+        CancellationToken ct = TestContext.Current.CancellationToken;
+
+        // Call the endpoint
+        var httpResponse = await Client.GetAsync("/admin/evaluators/available", ct);
+        httpResponse.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        var response = await httpResponse.Content.ReadFromJsonAsync<AvailableEvaluatorsResponse>(ct);
+
+        // Verify expected evaluators are present
+        response.ShouldNotBeNull();
+        response.EvaluatorNames.ShouldContain("BrevityEvaluator");
+        response.EvaluatorNames.ShouldContain("PlayerAgencyEvaluator");
+        response.EvaluatorNames.ShouldContain("GameMechanicsEvaluator");
+        response.EvaluatorNames.ShouldContain("StorytellerEvaluator");
+        response.EvaluatorNames.ShouldContain("RelevanceTruthAndCompletenessEvaluator");
+    }
+
+    [Fact]
+    public async Task ListAvailableEvaluators_ReturnsEvaluatorsInAlphabeticalOrder()
+    {
+        CancellationToken ct = TestContext.Current.CancellationToken;
+
+        // Call the endpoint
+        var httpResponse = await Client.GetAsync("/admin/evaluators/available", ct);
+        httpResponse.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        var response = await httpResponse.Content.ReadFromJsonAsync<AvailableEvaluatorsResponse>(ct);
+
+        // Verify evaluators are sorted alphabetically
+        response.ShouldNotBeNull();
+        var evaluatorNames = response.EvaluatorNames.ToList();
+        var sortedNames = evaluatorNames.OrderBy(n => n).ToList();
+        evaluatorNames.ShouldBe(sortedNames);
+    }
+}

--- a/JAIMES AF.Tests/Workers/GameMechanicsEvaluatorTests.cs
+++ b/JAIMES AF.Tests/Workers/GameMechanicsEvaluatorTests.cs
@@ -101,7 +101,7 @@ public class GameMechanicsEvaluatorTests
         metric.Reason.ShouldContain("follows game mechanics correctly");
 
         metric.Diagnostics.ShouldNotBeNull();
-        metric.Diagnostics.ShouldContain(d => d.Message.Contains("Game Mechanics Score: 5 (Pass)"));
+        metric.Diagnostics.ShouldContain(d => d.Message.Contains("GameMechanics Score: 5 (Pass)"));
         metric.Diagnostics.ShouldContain(d => d.Message.Contains("ThoughtChain:"));
     }
 
@@ -325,7 +325,7 @@ public class GameMechanicsEvaluatorTests
 
         var passDiagnostic = metric.Diagnostics?.FirstOrDefault(d => d.Message.Contains("(Pass)"));
         passDiagnostic.ShouldNotBeNull();
-        passDiagnostic!.Message.ShouldContain("Game Mechanics Score: 4 (Pass)");
+        passDiagnostic!.Message.ShouldContain("GameMechanics Score: 4 (Pass)");
     }
 
     [Fact]
@@ -358,7 +358,7 @@ public class GameMechanicsEvaluatorTests
 
         var failDiagnostic = metric.Diagnostics?.FirstOrDefault(d => d.Message.Contains("(Fail)"));
         failDiagnostic.ShouldNotBeNull();
-        failDiagnostic!.Message.ShouldContain("Game Mechanics Score: 3 (Fail)");
+        failDiagnostic!.Message.ShouldContain("GameMechanics Score: 3 (Fail)");
     }
 
     [Fact]

--- a/JAIMES AF.Tests/Workers/PlayerAgencyEvaluatorTests.cs
+++ b/JAIMES AF.Tests/Workers/PlayerAgencyEvaluatorTests.cs
@@ -62,7 +62,7 @@ public class PlayerAgencyEvaluatorTests
         metric.Reason.ShouldContain("respects player agency");
 
         metric.Diagnostics.ShouldNotBeNull();
-        metric.Diagnostics.ShouldContain(d => d.Message.Contains("Player Agency Score: 5 (Pass)"));
+        metric.Diagnostics.ShouldContain(d => d.Message.Contains("PlayerAgency Score: 5 (Pass)"));
         metric.Diagnostics.ShouldContain(d => d.Message.Contains("ThoughtChain:"));
     }
 
@@ -285,7 +285,7 @@ public class PlayerAgencyEvaluatorTests
 
         var passDiagnostic = metric.Diagnostics?.FirstOrDefault(d => d.Message.Contains("(Pass)"));
         passDiagnostic.ShouldNotBeNull();
-        passDiagnostic.Message.ShouldContain("Player Agency Score: 4 (Pass)");
+        passDiagnostic.Message.ShouldContain("PlayerAgency Score: 4 (Pass)");
     }
 
     [Fact]
@@ -317,7 +317,7 @@ public class PlayerAgencyEvaluatorTests
 
         var failDiagnostic = metric.Diagnostics?.FirstOrDefault(d => d.Message.Contains("(Fail)"));
         failDiagnostic.ShouldNotBeNull();
-        failDiagnostic.Message.ShouldContain("Player Agency Score: 3 (Fail)");
+        failDiagnostic.Message.ShouldContain("PlayerAgency Score: 3 (Fail)");
     }
 
     [Fact]

--- a/JAIMES AF.Tests/Workers/StorytellerEvaluatorTests.cs
+++ b/JAIMES AF.Tests/Workers/StorytellerEvaluatorTests.cs
@@ -1,0 +1,736 @@
+using MattEland.Jaimes.Evaluators;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.AI.Evaluation;
+using Moq;
+using Shouldly;
+
+namespace MattEland.Jaimes.Tests.Workers;
+
+public class StorytellerEvaluatorTests
+{
+    private readonly Mock<IChatClient> _mockChatClient;
+    private readonly StorytellerEvaluator _evaluator;
+
+    public StorytellerEvaluatorTests()
+    {
+        _mockChatClient = new Mock<IChatClient>();
+        _evaluator = new StorytellerEvaluator(_mockChatClient.Object);
+    }
+
+    [Fact]
+    public void EvaluationMetricNames_ShouldReturnStoryteller()
+    {
+        // Act
+        var metricNames = _evaluator.EvaluationMetricNames;
+
+        // Assert
+        metricNames.ShouldContain(StorytellerEvaluator.MetricName);
+        metricNames.Count.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task EvaluateAsync_WithValidS0S1S2Tags_ShouldParseCorrectly()
+    {
+        // Arrange
+        string responseText = """
+                              <S0>Let's think step by step: The narrative shows good progression with meaningful developments. Tension is present and fair.</S0>
+                              <S1>The storytelling maintains engagement with good pacing and clear hooks.</S1>
+                              <S2>5</S2>
+                              """;
+
+        _mockChatClient
+            .Setup(x => x.GetResponseAsync(It.IsAny<List<ChatMessage>>(), It.IsAny<ChatOptions>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ChatResponse(new ChatMessage(ChatRole.Assistant, responseText)));
+
+        var modelResponse = new ChatResponse(new ChatMessage(ChatRole.Assistant, "The ancient artifact glows with an otherworldly light as you approach."));
+        var messages = new List<ChatMessage>
+        {
+            new(ChatRole.System, "You are a game master."),
+            new(ChatRole.User, "I approach the altar."),
+            new(ChatRole.Assistant, "The ancient artifact glows with an otherworldly light as you approach.")
+        };
+
+        // Act
+        var result = await _evaluator.EvaluateAsync(messages, modelResponse,
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        // Assert
+        var metric = result.Get<NumericMetric>(StorytellerEvaluator.MetricName);
+        metric.ShouldNotBeNull();
+        metric.Value.ShouldBe(5);
+        metric.Reason.ShouldNotBeNull();
+        metric.Reason.ShouldContain("engagement");
+
+        metric.Diagnostics.ShouldNotBeNull();
+        metric.Diagnostics.ShouldContain(d => d.Message.Contains("Storyteller Score: 5 (Pass)"));
+        metric.Diagnostics.ShouldContain(d => d.Message.Contains("ThoughtChain:"));
+    }
+
+    [Fact]
+    public async Task EvaluateAsync_WithCaseInsensitiveTags_ShouldParseCorrectly()
+    {
+        // Arrange
+        string responseText = """
+                              <s0>Let's think step by step: Analysis here.</s0>
+                              <s1>Explanation here.</s1>
+                              <s2>4</s2>
+                              """;
+
+        _mockChatClient
+            .Setup(x => x.GetResponseAsync(It.IsAny<List<ChatMessage>>(), It.IsAny<ChatOptions>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ChatResponse(new ChatMessage(ChatRole.Assistant, responseText)));
+
+        var modelResponse = new ChatResponse(new ChatMessage(ChatRole.Assistant, "Test response."));
+        var messages = new List<ChatMessage>
+        {
+            new(ChatRole.User, "Test"),
+            new(ChatRole.Assistant, "Test response.")
+        };
+
+        // Act
+        var result = await _evaluator.EvaluateAsync(messages, modelResponse,
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        // Assert
+        var metric = result.Get<NumericMetric>(StorytellerEvaluator.MetricName);
+        metric.ShouldNotBeNull();
+        metric.Value.ShouldBe(4);
+        metric.Reason.ShouldBe("Explanation here.");
+    }
+
+    [Fact]
+    public async Task EvaluateAsync_WithMultipleExchanges_ShouldAnalyzeConversationTrends()
+    {
+        // Arrange
+        string responseText = """
+                              <S0>Let's think step by step: Analyzing 3 exchanges, the narrative shows consistent progression.</S0>
+                              <S1>Good storytelling with building tension across exchanges.</S1>
+                              <S2>4</S2>
+                              """;
+
+        _mockChatClient
+            .Setup(x => x.GetResponseAsync(It.IsAny<IEnumerable<ChatMessage>>(), It.IsAny<ChatOptions>(),
+                It.IsAny<CancellationToken>()))
+            .Callback<IEnumerable<ChatMessage>, ChatOptions, CancellationToken>((msgs, opts, ct) =>
+            {
+                // Verify conversation history is included with exchange markers
+                var userMessage = msgs.FirstOrDefault(m => m.Role == ChatRole.User);
+                userMessage.ShouldNotBeNull();
+                userMessage!.Text.ShouldContain("Exchange 1");
+                userMessage.Text.ShouldContain("Exchange 2");
+                userMessage.Text.ShouldContain("Exchange 3");
+            })
+            .ReturnsAsync(new ChatResponse(new ChatMessage(ChatRole.Assistant, responseText)));
+
+        var modelResponse = new ChatResponse(new ChatMessage(ChatRole.Assistant, "The dragon roars in fury!"));
+        var messages = new List<ChatMessage>
+        {
+            new(ChatRole.System, "You are a game master."),
+            new(ChatRole.User, "I enter the cave."),
+            new(ChatRole.Assistant, "The cave is dark and foreboding."),
+            new(ChatRole.User, "I light a torch."),
+            new(ChatRole.Assistant, "The torch reveals ancient carvings on the walls."),
+            new(ChatRole.User, "I examine the carvings."),
+            new(ChatRole.Assistant, "The dragon roars in fury!")
+        };
+
+        // Act
+        var result = await _evaluator.EvaluateAsync(messages, modelResponse,
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        // Assert
+        var metric = result.Get<NumericMetric>(StorytellerEvaluator.MetricName);
+        metric.ShouldNotBeNull();
+        metric.Value.ShouldBe(4);
+
+        metric.Diagnostics.ShouldNotBeNull();
+        metric.Diagnostics.ShouldContain(d => d.Message.Contains("Exchanges analyzed: 3"));
+    }
+
+    [Fact]
+    public async Task EvaluateAsync_WithFewExchanges_ShouldAddWarningDiagnostic()
+    {
+        // Arrange
+        string responseText = """
+                              <S0>Let's think step by step: Limited context available.</S0>
+                              <S1>Adequate storytelling but limited exchanges.</S1>
+                              <S2>4</S2>
+                              """;
+
+        _mockChatClient
+            .Setup(x => x.GetResponseAsync(It.IsAny<List<ChatMessage>>(), It.IsAny<ChatOptions>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ChatResponse(new ChatMessage(ChatRole.Assistant, responseText)));
+
+        var modelResponse = new ChatResponse(new ChatMessage(ChatRole.Assistant, "You see a door."));
+        var messages = new List<ChatMessage>
+        {
+            new(ChatRole.User, "I look around."),
+            new(ChatRole.Assistant, "You see a door.")
+        };
+
+        // Act
+        var result = await _evaluator.EvaluateAsync(messages, modelResponse,
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        // Assert
+        var metric = result.Get<NumericMetric>(StorytellerEvaluator.MetricName);
+        metric.ShouldNotBeNull();
+        metric.Value.ShouldBe(4); // Score should not be affected
+
+        // Should have warning about limited context
+        var warningDiagnostic = metric.Diagnostics?.FirstOrDefault(d =>
+            d.Severity == EvaluationDiagnosticSeverity.Warning &&
+            d.Message.Contains("Limited conversation context"));
+        warningDiagnostic.ShouldNotBeNull();
+        warningDiagnostic.Message.ShouldContain("1 exchange(s)");
+    }
+
+    [Fact]
+    public async Task EvaluateAsync_WithNoExchanges_ShouldAddWarningDiagnostic()
+    {
+        // Arrange
+        string responseText = """
+                              <S0>Let's think step by step: No prior context available.</S0>
+                              <S1>Cannot fully evaluate without context.</S1>
+                              <S2>3</S2>
+                              """;
+
+        _mockChatClient
+            .Setup(x => x.GetResponseAsync(It.IsAny<List<ChatMessage>>(), It.IsAny<ChatOptions>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ChatResponse(new ChatMessage(ChatRole.Assistant, responseText)));
+
+        var modelResponse = new ChatResponse(new ChatMessage(ChatRole.Assistant, "Welcome, adventurer."));
+        var messages = new List<ChatMessage>
+        {
+            new(ChatRole.System, "You are a game master.")
+        };
+
+        // Act
+        var result = await _evaluator.EvaluateAsync(messages, modelResponse,
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        // Assert
+        var metric = result.Get<NumericMetric>(StorytellerEvaluator.MetricName);
+        metric.ShouldNotBeNull();
+
+        // Should have warning about limited context
+        var warningDiagnostic = metric.Diagnostics?.FirstOrDefault(d =>
+            d.Severity == EvaluationDiagnosticSeverity.Warning &&
+            d.Message.Contains("Limited conversation context"));
+        warningDiagnostic.ShouldNotBeNull();
+        warningDiagnostic.Message.ShouldContain("0 exchange(s)");
+    }
+
+    [Fact]
+    public async Task EvaluateAsync_WithMultilineContent_ShouldParseCorrectly()
+    {
+        // Arrange
+        string responseText = """
+                              <S0>Let's think step by step:
+                              First, I analyze the narrative momentum.
+                              Then, I check for tension and challenge.
+                              Finally, I evaluate pacing.</S0>
+                              <S1>This is a multi-line explanation that should be parsed correctly.</S1>
+                              <S2>3</S2>
+                              """;
+
+        _mockChatClient
+            .Setup(x => x.GetResponseAsync(It.IsAny<List<ChatMessage>>(), It.IsAny<ChatOptions>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ChatResponse(new ChatMessage(ChatRole.Assistant, responseText)));
+
+        var modelResponse = new ChatResponse(new ChatMessage(ChatRole.Assistant, "Test response."));
+        var messages = new List<ChatMessage>
+        {
+            new(ChatRole.User, "Test"),
+            new(ChatRole.Assistant, "Test response.")
+        };
+
+        // Act
+        var result = await _evaluator.EvaluateAsync(messages, modelResponse,
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        // Assert
+        var metric = result.Get<NumericMetric>(StorytellerEvaluator.MetricName);
+        metric.ShouldNotBeNull();
+        metric.Value.ShouldBe(3);
+        metric.Reason.ShouldNotBeNull();
+        metric.Reason.ShouldContain("multi-line explanation");
+
+        var thoughtChainDiagnostic = metric.Diagnostics?.FirstOrDefault(d => d.Message.Contains("ThoughtChain:"));
+        thoughtChainDiagnostic.ShouldNotBeNull();
+        thoughtChainDiagnostic!.Message.ShouldContain("First, I analyze");
+    }
+
+    [Fact]
+    public async Task EvaluateAsync_WithMissingS0Tag_ShouldStillParseS1AndS2()
+    {
+        // Arrange
+        string responseText = """
+                              <S1>Explanation without ThoughtChain.</S1>
+                              <S2>2</S2>
+                              """;
+
+        _mockChatClient
+            .Setup(x => x.GetResponseAsync(It.IsAny<List<ChatMessage>>(), It.IsAny<ChatOptions>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ChatResponse(new ChatMessage(ChatRole.Assistant, responseText)));
+
+        var modelResponse = new ChatResponse(new ChatMessage(ChatRole.Assistant, "Test response."));
+        var messages = new List<ChatMessage>
+        {
+            new(ChatRole.User, "Test"),
+            new(ChatRole.Assistant, "Test response.")
+        };
+
+        // Act
+        var result = await _evaluator.EvaluateAsync(messages, modelResponse,
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        // Assert
+        var metric = result.Get<NumericMetric>(StorytellerEvaluator.MetricName);
+        metric.ShouldNotBeNull();
+        metric.Value.ShouldBe(2);
+        metric.Reason.ShouldBe("Explanation without ThoughtChain.");
+
+        // Should not have ThoughtChain diagnostic
+        var thoughtChainDiagnostic = metric.Diagnostics?.FirstOrDefault(d => d.Message.Contains("ThoughtChain:"));
+        thoughtChainDiagnostic.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task EvaluateAsync_WithMissingS2Tag_ShouldUseDefaultScore()
+    {
+        // Arrange
+        string responseText = """
+                              <S0>Let's think step by step: Analysis here.</S0>
+                              <S1>Explanation here.</S1>
+                              """;
+
+        _mockChatClient
+            .Setup(x => x.GetResponseAsync(It.IsAny<List<ChatMessage>>(), It.IsAny<ChatOptions>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ChatResponse(new ChatMessage(ChatRole.Assistant, responseText)));
+
+        var modelResponse = new ChatResponse(new ChatMessage(ChatRole.Assistant, "Test response."));
+        var messages = new List<ChatMessage>
+        {
+            new(ChatRole.User, "Test"),
+            new(ChatRole.Assistant, "Test response.")
+        };
+
+        // Act
+        var result = await _evaluator.EvaluateAsync(messages, modelResponse,
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        // Assert
+        var metric = result.Get<NumericMetric>(StorytellerEvaluator.MetricName);
+        metric.ShouldNotBeNull();
+        metric.Value.ShouldBe(1); // Default score when parsing fails
+        metric.Reason.ShouldBe("Explanation here.");
+
+        // Should have warning about parsing failure
+        var warningDiagnostic = metric.Diagnostics?.FirstOrDefault(d =>
+            d.Severity == EvaluationDiagnosticSeverity.Warning &&
+            d.Message.Contains("Failed to parse evaluation response"));
+        warningDiagnostic.ShouldNotBeNull();
+    }
+
+    [Fact]
+    public async Task EvaluateAsync_WithInvalidScore_ShouldClampToValidRange()
+    {
+        // Arrange
+        string responseText = """
+                              <S0>Let's think step by step: Analysis.</S0>
+                              <S1>Explanation.</S1>
+                              <S2>10</S2>
+                              """;
+
+        _mockChatClient
+            .Setup(x => x.GetResponseAsync(It.IsAny<List<ChatMessage>>(), It.IsAny<ChatOptions>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ChatResponse(new ChatMessage(ChatRole.Assistant, responseText)));
+
+        var modelResponse = new ChatResponse(new ChatMessage(ChatRole.Assistant, "Test response."));
+        var messages = new List<ChatMessage>
+        {
+            new(ChatRole.User, "Test"),
+            new(ChatRole.Assistant, "Test response.")
+        };
+
+        // Act
+        var result = await _evaluator.EvaluateAsync(messages, modelResponse,
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        // Assert
+        var metric = result.Get<NumericMetric>(StorytellerEvaluator.MetricName);
+        metric.ShouldNotBeNull();
+        metric.Value.ShouldBe(5); // Clamped to max
+    }
+
+    [Fact]
+    public async Task EvaluateAsync_WithNegativeScore_ShouldClampToValidRange()
+    {
+        // Arrange
+        string responseText = """
+                              <S0>Let's think step by step: Analysis.</S0>
+                              <S1>Explanation.</S1>
+                              <S2>-5</S2>
+                              """;
+
+        _mockChatClient
+            .Setup(x => x.GetResponseAsync(It.IsAny<List<ChatMessage>>(), It.IsAny<ChatOptions>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ChatResponse(new ChatMessage(ChatRole.Assistant, responseText)));
+
+        var modelResponse = new ChatResponse(new ChatMessage(ChatRole.Assistant, "Test response."));
+        var messages = new List<ChatMessage>
+        {
+            new(ChatRole.User, "Test"),
+            new(ChatRole.Assistant, "Test response.")
+        };
+
+        // Act
+        var result = await _evaluator.EvaluateAsync(messages, modelResponse,
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        // Assert
+        var metric = result.Get<NumericMetric>(StorytellerEvaluator.MetricName);
+        metric.ShouldNotBeNull();
+        metric.Value.ShouldBe(1); // Clamped to min
+    }
+
+    [Fact]
+    public async Task EvaluateAsync_WithScore4_ShouldMarkAsPass()
+    {
+        // Arrange
+        string responseText = """
+                              <S0>Let's think step by step: Analysis.</S0>
+                              <S1>Explanation.</S1>
+                              <S2>4</S2>
+                              """;
+
+        _mockChatClient
+            .Setup(x => x.GetResponseAsync(It.IsAny<List<ChatMessage>>(), It.IsAny<ChatOptions>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ChatResponse(new ChatMessage(ChatRole.Assistant, responseText)));
+
+        var modelResponse = new ChatResponse(new ChatMessage(ChatRole.Assistant, "Test response."));
+        var messages = new List<ChatMessage>
+        {
+            new(ChatRole.User, "Test"),
+            new(ChatRole.Assistant, "Test response.")
+        };
+
+        // Act
+        var result = await _evaluator.EvaluateAsync(messages, modelResponse,
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        // Assert
+        var metric = result.Get<NumericMetric>(StorytellerEvaluator.MetricName);
+        metric.ShouldNotBeNull();
+        metric.Value.ShouldBe(4);
+
+        var passDiagnostic = metric.Diagnostics?.FirstOrDefault(d => d.Message.Contains("(Pass)"));
+        passDiagnostic.ShouldNotBeNull();
+        passDiagnostic.Message.ShouldContain("Storyteller Score: 4 (Pass)");
+    }
+
+    [Fact]
+    public async Task EvaluateAsync_WithScore3_ShouldMarkAsFail()
+    {
+        // Arrange
+        string responseText = """
+                              <S0>Let's think step by step: Analysis.</S0>
+                              <S1>Explanation.</S1>
+                              <S2>3</S2>
+                              """;
+
+        _mockChatClient
+            .Setup(x => x.GetResponseAsync(It.IsAny<List<ChatMessage>>(), It.IsAny<ChatOptions>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ChatResponse(new ChatMessage(ChatRole.Assistant, responseText)));
+
+        var modelResponse = new ChatResponse(new ChatMessage(ChatRole.Assistant, "Test response."));
+        var messages = new List<ChatMessage>
+        {
+            new(ChatRole.User, "Test"),
+            new(ChatRole.Assistant, "Test response.")
+        };
+
+        // Act
+        var result = await _evaluator.EvaluateAsync(messages, modelResponse,
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        // Assert
+        var metric = result.Get<NumericMetric>(StorytellerEvaluator.MetricName);
+        metric.ShouldNotBeNull();
+        metric.Value.ShouldBe(3);
+
+        var failDiagnostic = metric.Diagnostics?.FirstOrDefault(d => d.Message.Contains("(Fail)"));
+        failDiagnostic.ShouldNotBeNull();
+        failDiagnostic.Message.ShouldContain("Storyteller Score: 3 (Fail)");
+    }
+
+    [Fact]
+    public async Task EvaluateAsync_WithEmptyResponse_ShouldUseDefaultValues()
+    {
+        // Arrange
+        _mockChatClient
+            .Setup(x => x.GetResponseAsync(It.IsAny<List<ChatMessage>>(), It.IsAny<ChatOptions>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ChatResponse(new ChatMessage(ChatRole.Assistant, string.Empty)));
+
+        var modelResponse = new ChatResponse(new ChatMessage(ChatRole.Assistant, "Test response."));
+        var messages = new List<ChatMessage>
+        {
+            new(ChatRole.User, "Test"),
+            new(ChatRole.Assistant, "Test response.")
+        };
+
+        // Act
+        var result = await _evaluator.EvaluateAsync(messages, modelResponse,
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        // Assert
+        var metric = result.Get<NumericMetric>(StorytellerEvaluator.MetricName);
+        metric.ShouldNotBeNull();
+        metric.Value.ShouldBe(1); // Default score
+        metric.Reason.ShouldBe("Failed to parse evaluation response.");
+
+        var warningDiagnostic = metric.Diagnostics?.FirstOrDefault(d =>
+            d.Severity == EvaluationDiagnosticSeverity.Warning &&
+            d.Message.Contains("Failed to parse evaluation response"));
+        warningDiagnostic.ShouldNotBeNull();
+    }
+
+    [Fact]
+    public async Task EvaluateAsync_WithNullResponse_ShouldUseDefaultValues()
+    {
+        // Arrange
+        _mockChatClient
+            .Setup(x => x.GetResponseAsync(It.IsAny<List<ChatMessage>>(), It.IsAny<ChatOptions>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ChatResponse(new ChatMessage(ChatRole.Assistant, (string?)null)));
+
+        var modelResponse = new ChatResponse(new ChatMessage(ChatRole.Assistant, "Test response."));
+        var messages = new List<ChatMessage>
+        {
+            new(ChatRole.User, "Test"),
+            new(ChatRole.Assistant, "Test response.")
+        };
+
+        // Act
+        var result = await _evaluator.EvaluateAsync(messages, modelResponse,
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        // Assert
+        var metric = result.Get<NumericMetric>(StorytellerEvaluator.MetricName);
+        metric.ShouldNotBeNull();
+        metric.Value.ShouldBe(1); // Default score
+        metric.Reason.ShouldBe("Failed to parse evaluation response.");
+
+        var warningDiagnostic = metric.Diagnostics?.FirstOrDefault(d =>
+            d.Severity == EvaluationDiagnosticSeverity.Warning &&
+            d.Message.Contains("Failed to parse evaluation response. Raw response: {Empty}"));
+        warningDiagnostic.ShouldNotBeNull();
+    }
+
+    [Fact]
+    public async Task EvaluateAsync_WithSystemPrompt_ShouldIncludeInPrompt()
+    {
+        // Arrange
+        string responseText = """
+                              <S0>Let's think step by step: Analysis.</S0>
+                              <S1>Explanation.</S1>
+                              <S2>5</S2>
+                              """;
+
+        _mockChatClient
+            .Setup(x => x.GetResponseAsync(It.IsAny<IEnumerable<ChatMessage>>(), It.IsAny<ChatOptions>(),
+                It.IsAny<CancellationToken>()))
+            .Callback<IEnumerable<ChatMessage>, ChatOptions, CancellationToken>((msgs, opts, ct) =>
+            {
+                // Verify system prompt is included
+                var userMessage = msgs.FirstOrDefault(m => m.Role == ChatRole.User);
+                userMessage.ShouldNotBeNull();
+                userMessage!.Text.ShouldContain("System Instructions for the Game Master:");
+                userMessage.Text.ShouldContain("You are a test game master.");
+            })
+            .ReturnsAsync(new ChatResponse(new ChatMessage(ChatRole.Assistant, responseText)));
+
+        var modelResponse = new ChatResponse(new ChatMessage(ChatRole.Assistant, "Test response."));
+        var messages = new List<ChatMessage>
+        {
+            new(ChatRole.System, "You are a test game master."),
+            new(ChatRole.User, "Test"),
+            new(ChatRole.Assistant, "Test response.")
+        };
+
+        // Act
+        var result = await _evaluator.EvaluateAsync(messages, modelResponse,
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        // Assert
+        var metric = result.Get<NumericMetric>(StorytellerEvaluator.MetricName);
+        metric.ShouldNotBeNull();
+        metric.Value.ShouldBe(5);
+    }
+
+    [Fact]
+    public async Task EvaluateAsync_WithFiveExchanges_ShouldNotAddWarningDiagnostic()
+    {
+        // Arrange
+        string responseText = """
+                              <S0>Let's think step by step: Full context available for analysis.</S0>
+                              <S1>Excellent storytelling with consistent quality.</S1>
+                              <S2>5</S2>
+                              """;
+
+        _mockChatClient
+            .Setup(x => x.GetResponseAsync(It.IsAny<List<ChatMessage>>(), It.IsAny<ChatOptions>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ChatResponse(new ChatMessage(ChatRole.Assistant, responseText)));
+
+        var modelResponse = new ChatResponse(new ChatMessage(ChatRole.Assistant, "The final response."));
+        var messages = new List<ChatMessage>
+        {
+            new(ChatRole.System, "You are a game master."),
+            new(ChatRole.User, "Exchange 1 user"),
+            new(ChatRole.Assistant, "Exchange 1 assistant"),
+            new(ChatRole.User, "Exchange 2 user"),
+            new(ChatRole.Assistant, "Exchange 2 assistant"),
+            new(ChatRole.User, "Exchange 3 user"),
+            new(ChatRole.Assistant, "Exchange 3 assistant"),
+            new(ChatRole.User, "Exchange 4 user"),
+            new(ChatRole.Assistant, "Exchange 4 assistant"),
+            new(ChatRole.User, "Exchange 5 user"),
+            new(ChatRole.Assistant, "The final response.")
+        };
+
+        // Act
+        var result = await _evaluator.EvaluateAsync(messages, modelResponse,
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        // Assert
+        var metric = result.Get<NumericMetric>(StorytellerEvaluator.MetricName);
+        metric.ShouldNotBeNull();
+        metric.Value.ShouldBe(5);
+
+        // Should have exchanges analyzed diagnostic
+        metric.Diagnostics.ShouldNotBeNull();
+        metric.Diagnostics!.ShouldContain(d => d.Message.Contains("Exchanges analyzed: 5"));
+
+        // Should NOT have warning about limited context
+        var warningDiagnostic = metric.Diagnostics.FirstOrDefault(d =>
+            d.Severity == EvaluationDiagnosticSeverity.Warning &&
+            d.Message.Contains("Limited conversation context"));
+        warningDiagnostic.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task EvaluateAsync_WithThreeExchanges_ShouldNotAddWarningDiagnostic()
+    {
+        // Arrange - 3 exchanges is the minimum threshold, should NOT trigger warning
+        string responseText = """
+                              <S0>Let's think step by step: Adequate context for analysis.</S0>
+                              <S1>Good storytelling observed.</S1>
+                              <S2>4</S2>
+                              """;
+
+        _mockChatClient
+            .Setup(x => x.GetResponseAsync(It.IsAny<List<ChatMessage>>(), It.IsAny<ChatOptions>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ChatResponse(new ChatMessage(ChatRole.Assistant, responseText)));
+
+        var modelResponse = new ChatResponse(new ChatMessage(ChatRole.Assistant, "Third response."));
+        var messages = new List<ChatMessage>
+        {
+            new(ChatRole.User, "First message"),
+            new(ChatRole.Assistant, "First response"),
+            new(ChatRole.User, "Second message"),
+            new(ChatRole.Assistant, "Second response"),
+            new(ChatRole.User, "Third message"),
+            new(ChatRole.Assistant, "Third response.")
+        };
+
+        // Act
+        var result = await _evaluator.EvaluateAsync(messages, modelResponse,
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        // Assert
+        var metric = result.Get<NumericMetric>(StorytellerEvaluator.MetricName);
+        metric.ShouldNotBeNull();
+
+        // Should have exchanges analyzed diagnostic
+        metric.Diagnostics.ShouldNotBeNull();
+        metric.Diagnostics!.ShouldContain(d => d.Message.Contains("Exchanges analyzed: 3"));
+
+        // Should NOT have warning about limited context (3 is the threshold)
+        var warningDiagnostic = metric.Diagnostics.FirstOrDefault(d =>
+            d.Severity == EvaluationDiagnosticSeverity.Warning &&
+            d.Message.Contains("Limited conversation context"));
+        warningDiagnostic.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task EvaluateAsync_WithMoreThanFiveExchanges_ShouldOnlyAnalyzeLastFive()
+    {
+        // Arrange
+        string responseText = """
+                              <S0>Let's think step by step: Analysis of recent exchanges.</S0>
+                              <S1>Good storytelling in recent interactions.</S1>
+                              <S2>4</S2>
+                              """;
+
+        _mockChatClient
+            .Setup(x => x.GetResponseAsync(It.IsAny<IEnumerable<ChatMessage>>(), It.IsAny<ChatOptions>(),
+                It.IsAny<CancellationToken>()))
+            .Callback<IEnumerable<ChatMessage>, ChatOptions, CancellationToken>((msgs, opts, ct) =>
+            {
+                var userMessage = msgs.FirstOrDefault(m => m.Role == ChatRole.User);
+                userMessage.ShouldNotBeNull();
+                // Should only contain exchanges 4-8 (the last 5), not exchanges 1-3
+                userMessage!.Text.ShouldNotContain("Very old exchange");
+                userMessage.Text.ShouldContain("Exchange 4");
+                userMessage.Text.ShouldContain("Exchange 8");
+            })
+            .ReturnsAsync(new ChatResponse(new ChatMessage(ChatRole.Assistant, responseText)));
+
+        var modelResponse = new ChatResponse(new ChatMessage(ChatRole.Assistant, "Exchange 8 response"));
+        var messages = new List<ChatMessage>
+        {
+            new(ChatRole.User, "Very old exchange 1"),
+            new(ChatRole.Assistant, "Very old response 1"),
+            new(ChatRole.User, "Very old exchange 2"),
+            new(ChatRole.Assistant, "Very old response 2"),
+            new(ChatRole.User, "Very old exchange 3"),
+            new(ChatRole.Assistant, "Very old response 3"),
+            new(ChatRole.User, "Exchange 4"),
+            new(ChatRole.Assistant, "Exchange 4 response"),
+            new(ChatRole.User, "Exchange 5"),
+            new(ChatRole.Assistant, "Exchange 5 response"),
+            new(ChatRole.User, "Exchange 6"),
+            new(ChatRole.Assistant, "Exchange 6 response"),
+            new(ChatRole.User, "Exchange 7"),
+            new(ChatRole.Assistant, "Exchange 7 response"),
+            new(ChatRole.User, "Exchange 8"),
+            new(ChatRole.Assistant, "Exchange 8 response")
+        };
+
+        // Act
+        var result = await _evaluator.EvaluateAsync(messages, modelResponse,
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        // Assert
+        var metric = result.Get<NumericMetric>(StorytellerEvaluator.MetricName);
+        metric.ShouldNotBeNull();
+        metric.Value.ShouldBe(4);
+        metric.Diagnostics.ShouldNotBeNull();
+        metric.Diagnostics!.ShouldContain(d => d.Message.Contains("Exchanges analyzed: 5"));
+    }
+}

--- a/JAIMES AF.Web/Components/Pages/EvaluatorTest.razor.cs
+++ b/JAIMES AF.Web/Components/Pages/EvaluatorTest.razor.cs
@@ -21,13 +21,7 @@ public partial class EvaluatorTest
     private readonly Dictionary<int, AgentInstructionVersionResponse> _versionLookup = new();
     private readonly List<AgentVersionOption> _versionOptions = [];
     private RulesetInfoResponse[] _rulesets = [];
-    private readonly List<string> _availableEvaluators =
-    [
-        "BrevityEvaluator",
-        "PlayerAgencyEvaluator",
-        "GameMechanicsEvaluator",
-        "RelevanceTruthAndCompletenessEvaluator"
-    ];
+    private List<string> _availableEvaluators = [];
 
     // Form state
     private int _selectedVersionId;
@@ -62,14 +56,16 @@ public partial class EvaluatorTest
 
         try
         {
-            // Load agents and rulesets in parallel
+            // Load agents, rulesets, and available evaluators in parallel
             Task<AgentListResponse?> agentsTask = Http.GetFromJsonAsync<AgentListResponse>("/agents");
             Task<RulesetListResponse?> rulesetsTask = Http.GetFromJsonAsync<RulesetListResponse>("/rulesets");
+            Task<AvailableEvaluatorsResponse?> evaluatorsTask = Http.GetFromJsonAsync<AvailableEvaluatorsResponse>("/admin/evaluators/available");
 
-            await Task.WhenAll(agentsTask, rulesetsTask);
+            await Task.WhenAll(agentsTask, rulesetsTask, evaluatorsTask);
 
             _agents = agentsTask.Result?.Agents ?? [];
             _rulesets = rulesetsTask.Result?.Rulesets ?? [];
+            _availableEvaluators = evaluatorsTask.Result?.EvaluatorNames ?? [];
 
             await LoadAllVersionsAsync();
 


### PR DESCRIPTION
- Implemented StorytellerEvaluator to assess narrative engagement and storytelling quality in AI-driven conversations.
- Created AvailableEvaluatorsResponse to dynamically list available evaluators.
- Added endpoint tests for listing available evaluators, ensuring correct evaluators are returned and sorted.
- Developed comprehensive unit tests for StorytellerEvaluator, covering various scenarios including parsing responses, handling multiple exchanges, and validating score ranges.
- Updated EvaluatorTest component to fetch available evaluators from the API.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds narrative-trend evaluation and consolidates evaluator logic, plus surfaces evaluators to the UI.
> 
> - New `StorytellerEvaluator` scores storytelling across recent exchanges, adds diagnostics for exchange count, and warns on limited context
> - Introduces `LlmBasedEvaluator` and `EvaluationParseResult`; refactors `PlayerAgencyEvaluator` and `GameMechanicsEvaluator` to inherit it, centralizing LLM calls, tag parsing (S0/S1/S2), and metric diagnostics
> - New `GET /admin/evaluators/available` endpoint returning `AvailableEvaluatorsResponse`; `EvaluatorTest` now fetches evaluator names from the API instead of hardcoding
> - Tests: comprehensive `StorytellerEvaluator` unit tests; updated `GameMechanicsEvaluator` and `PlayerAgencyEvaluator` tests to new diagnostics; new endpoint tests for presence/sorting of evaluators
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 176b9e4e8730157fb1496fe0c2b4de43cefced78. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->