### PR TITLE
JAF-137, JAF-133 improve contrast

### DIFF
--- a/JAIMES AF.Web/Components/Chat/AssistantChatMessage.razor
+++ b/JAIMES AF.Web/Components/Chat/AssistantChatMessage.razor
@@ -7,7 +7,7 @@
 {
     <ChatBubble Position="ChatBubblePosition.Start"
                 Variant="Variant.Filled"
-                Color="@(Highlighted ? Color.Primary : Color)">
+                Color="@(Highlighted ? Color.Info : Color)">
         @if (IsFirstParagraph)
         {
             <ChatHeader Name="Game Master"/>

--- a/JAIMES AF.Web/Components/Layout/MainLayout.razor
+++ b/JAIMES AF.Web/Components/Layout/MainLayout.razor
@@ -46,8 +46,8 @@
 		{
 			Primary = "#7B2CBF",           // Purple
 			Secondary = "#4361EE",         // Blue
-			Tertiary = "#FF9800",          // Orange
-			Info = "#4CC9F0",              // Cyan / Teal
+			Tertiary = "#2F9E9E",          // Teal (for assistant messages)
+			Info = "#4CC9F0",              // Cyan (for highlighted messages)
 			Success = "#06D6A0",           // Green
 			Warning = "#FFD60A",           // Yellow
 			Error = "#EF476F",             // Red/Pink

--- a/JAIMES AF.Web/wwwroot/app.css
+++ b/JAIMES AF.Web/wwwroot/app.css
@@ -1339,9 +1339,9 @@ th.comparison-matrix-sticky-column {
 }
 
 .chat-bubble-filled.chat-bubble-info>div:not(.chat-header):not(.chat-footer) {
-    background-color: #E0F7FF;
+    background-color: #FFF8E1;
     color: #2B2D42;
-    border: 2px solid #3BA8C9;
+    border: 2px solid #F59E0B;
 }
 
 .chat-bubble-filled.chat-bubble-success>div:not(.chat-header):not(.chat-footer) {
@@ -1415,7 +1415,7 @@ th.comparison-matrix-sticky-column {
 
 /* Highlighted assistant messages use info color with start position (::before) */
 .chat-bubble-filled.chat-bubble-info .chat-bubble-content.has-pointer::before {
-    border-right-color: #3BA8C9;
+    border-right-color: #F59E0B;
 }
 
 /* Tertiary assistant messages pointer */

--- a/JAIMES AF.Web/wwwroot/app.css
+++ b/JAIMES AF.Web/wwwroot/app.css
@@ -1345,23 +1345,27 @@ th.comparison-matrix-sticky-column {
 }
 
 .chat-bubble-filled.chat-bubble-success>div:not(.chat-header):not(.chat-footer) {
-    background-color: var(--mud-palette-success);
-    color: var(--mud-palette-success-text);
+    background-color: #E8F8F1;
+    color: #2B2D42;
+    border: 2px solid #06D6A0;
 }
 
 .chat-bubble-filled.chat-bubble-warning>div:not(.chat-header):not(.chat-footer) {
-    background-color: var(--mud-palette-warning);
-    color: var(--mud-palette-warning-text);
+    background-color: #FFF8E1;
+    color: #2B2D42;
+    border: 2px solid #FFD60A;
 }
 
 .chat-bubble-filled.chat-bubble-error>div:not(.chat-header):not(.chat-footer) {
-    background-color: var(--mud-palette-error);
-    color: var(--mud-palette-error-text);
+    background-color: #FDECEF;
+    color: #2B2D42;
+    border: 2px solid #EF476F;
 }
 
 .chat-bubble-filled.chat-bubble-dark>div:not(.chat-header):not(.chat-footer) {
-    background-color: var(--mud-palette-dark);
-    color: var(--mud-palette-dark-text);
+    background-color: #E8E8EC;
+    color: #2B2D42;
+    border: 2px solid #2B2D42;
 }
 
 /* Bubble corner radius adjustments based on position */

--- a/JAIMES AF.Web/wwwroot/app.css
+++ b/JAIMES AF.Web/wwwroot/app.css
@@ -10,7 +10,7 @@
 
     /* Secondary Colors */
     --color-secondary: #4361EE;
-    --color-tertiary: #FF9800;
+    --color-tertiary: #2F9E9E;
     --color-accent: #06D6A0;
 
     /* Semantic Colors */
@@ -1303,10 +1303,11 @@ th.comparison-matrix-sticky-column {
     color: var(--mud-palette-text-primary);
 }
 
-/* Default/Assistant messages - secondary color for better contrast */
+/* Default/Assistant messages - soft teal for better readability on projectors */
 .chat-bubble-filled.chat-bubble-default>div:not(.chat-header):not(.chat-footer) {
-    background-color: var(--mud-palette-secondary);
-    color: var(--mud-palette-secondary-text);
+    background-color: #E0F5F5;
+    color: #2B2D42;
+    border: 2px solid #2F9E9E;
 }
 
 /* Outlined Variant */
@@ -1320,18 +1321,27 @@ th.comparison-matrix-sticky-column {
 
 /* Color Variants - Filled */
 .chat-bubble-filled.chat-bubble-primary>div:not(.chat-header):not(.chat-footer) {
-    background-color: var(--mud-palette-primary);
-    color: var(--mud-palette-primary-text);
+    background-color: #F3E8FF;
+    color: #2B2D42;
+    border: 2px solid #7B2CBF;
 }
 
 .chat-bubble-filled.chat-bubble-secondary>div:not(.chat-header):not(.chat-footer) {
-    background-color: var(--mud-palette-secondary);
-    color: var(--mud-palette-secondary-text);
+    background-color: #E8EDFF;
+    color: #2B2D42;
+    border: 2px solid #4361EE;
+}
+
+.chat-bubble-filled.chat-bubble-tertiary>div:not(.chat-header):not(.chat-footer) {
+    background-color: #E0F5F5;
+    color: #2B2D42;
+    border: 2px solid #2F9E9E;
 }
 
 .chat-bubble-filled.chat-bubble-info>div:not(.chat-header):not(.chat-footer) {
-    background-color: var(--mud-palette-info);
-    color: var(--mud-palette-info-text);
+    background-color: #E0F7FF;
+    color: #2B2D42;
+    border: 2px solid #3BA8C9;
 }
 
 .chat-bubble-filled.chat-bubble-success>div:not(.chat-header):not(.chat-footer) {
@@ -1378,20 +1388,20 @@ th.comparison-matrix-sticky-column {
     height: 0;
     border-top: 6px solid transparent;
     border-bottom: 6px solid transparent;
-    border-right: 8px solid var(--mud-palette-secondary);
+    border-right: 8px solid #2F9E9E;
 }
 
 /* Right pointer for user/end messages */
 .chat-bubble-end .chat-bubble-content.has-pointer::after {
     content: '';
     position: absolute;
-    right: -8px;
+    right: -10px;
     top: 12px;
     width: 0;
     height: 0;
     border-top: 6px solid transparent;
     border-bottom: 6px solid transparent;
-    border-left: 8px solid var(--mud-palette-primary);
+    border-left: 8px solid #7B2CBF;
 }
 
 /* Pointer color variants */
@@ -1403,9 +1413,19 @@ th.comparison-matrix-sticky-column {
     border-left-color: var(--mud-palette-primary);
 }
 
-/* Highlighted assistant messages use primary color with start position (::before) */
-.chat-bubble-filled.chat-bubble-primary .chat-bubble-content.has-pointer::before {
-    border-right-color: var(--mud-palette-primary);
+/* Highlighted assistant messages use info color with start position (::before) */
+.chat-bubble-filled.chat-bubble-info .chat-bubble-content.has-pointer::before {
+    border-right-color: #3BA8C9;
+}
+
+/* Tertiary assistant messages pointer */
+.chat-bubble-filled.chat-bubble-tertiary .chat-bubble-content.has-pointer::before {
+    border-right-color: #2F9E9E;
+}
+
+/* Primary messages pointer */
+.chat-bubble-filled.chat-bubble-primary .chat-bubble-content.has-pointer::after {
+    border-left-color: #7B2CBF;
 }
 
 .chat-bubble-filled.chat-bubble-error .chat-bubble-content.has-pointer::before {

--- a/JAIMES AF.Web/wwwroot/app.css
+++ b/JAIMES AF.Web/wwwroot/app.css
@@ -611,8 +611,8 @@ h1:focus {
 }
 
 .icon-badge-tertiary {
-    background: linear-gradient(135deg, var(--color-tertiary) 0%, #FFB74D 100%);
-    box-shadow: 0 4px 12px rgba(255, 152, 0, 0.3);
+    background: linear-gradient(135deg, var(--color-tertiary) 0%, #4DB6AC 100%);
+    box-shadow: 0 4px 12px rgba(47, 158, 158, 0.3);
 }
 
 .icon-badge-accent {

--- a/JAIMES AF.Web/wwwroot/app.css
+++ b/JAIMES AF.Web/wwwroot/app.css
@@ -1382,7 +1382,7 @@ th.comparison-matrix-sticky-column {
 .chat-bubble-start .chat-bubble-content.has-pointer::before {
     content: '';
     position: absolute;
-    left: -8px;
+    left: -10px;
     top: 12px;
     width: 0;
     height: 0;
@@ -1426,6 +1426,11 @@ th.comparison-matrix-sticky-column {
 /* Primary messages pointer */
 .chat-bubble-filled.chat-bubble-primary .chat-bubble-content.has-pointer::after {
     border-left-color: #7B2CBF;
+}
+
+/* Primary start position pointer (for assistant messages with Color.Primary) */
+.chat-bubble-filled.chat-bubble-primary .chat-bubble-content.has-pointer::before {
+    border-right-color: #7B2CBF;
 }
 
 .chat-bubble-filled.chat-bubble-error .chat-bubble-content.has-pointer::before {

--- a/JAIMES AF.Web/wwwroot/app.css
+++ b/JAIMES AF.Web/wwwroot/app.css
@@ -1406,7 +1406,7 @@ th.comparison-matrix-sticky-column {
 
 /* Pointer color variants */
 .chat-bubble-filled.chat-bubble-info .chat-bubble-content.has-pointer::after {
-    border-left-color: var(--mud-palette-info);
+    border-left-color: #F59E0B;
 }
 
 .chat-bubble-filled.chat-bubble-primary .chat-bubble-content.has-pointer::after {
@@ -1435,6 +1435,15 @@ th.comparison-matrix-sticky-column {
 
 .chat-bubble-filled.chat-bubble-error .chat-bubble-content.has-pointer::before {
     border-right-color: var(--mud-palette-error);
+}
+
+/* Secondary messages pointer */
+.chat-bubble-filled.chat-bubble-secondary .chat-bubble-content.has-pointer::before {
+    border-right-color: #4361EE;
+}
+
+.chat-bubble-filled.chat-bubble-secondary .chat-bubble-content.has-pointer::after {
+    border-left-color: #4361EE;
 }
 
 /* Chat Header */


### PR DESCRIPTION
This pull request updates the color palette and chat bubble styling to improve readability and visual distinction in the chat UI, especially for assistant messages and highlighted responses. The changes affect both the CSS and the Razor component logic, introducing new colors and adjusting how highlighted and default assistant messages are rendered.

**Color palette and theme adjustments:**

* Changed the `Tertiary` color from orange to teal in `MainLayout.razor` and `app.css`, making assistant messages more visually distinct. [[1]](diffhunk://#diff-2306e8409145cf137be79687c3a62dc94f63a011f7d46ff09b8c477d448db51cL49-R50) [[2]](diffhunk://#diff-1b582670b4467a3522d1c5e2bd7b0983dd99d49fecdae254446a1b87246edff5L13-R13)
* Updated the meaning of the `Info` color to cyan, specifically for highlighted messages, in both theme and usage.

**Chat bubble styling improvements:**

* Updated the default assistant message bubble to use a soft teal background, dark text, and a teal border for better readability on projectors.
* Added a new `.chat-bubble-tertiary` style for assistant messages, and adjusted `.chat-bubble-primary`, `.chat-bubble-secondary`, and `.chat-bubble-info` to use custom backgrounds and borders for improved contrast and clarity.
* Refined the pointer (arrow) colors and positions for chat bubbles, including new pointer colors for tertiary and info variants, and adjusted the right pointer position for end messages. [[1]](diffhunk://#diff-1b582670b4467a3522d1c5e2bd7b0983dd99d49fecdae254446a1b87246edff5L1381-R1404) [[2]](diffhunk://#diff-1b582670b4467a3522d1c5e2bd7b0983dd99d49fecdae254446a1b87246edff5L1406-R1428)

**Component logic update:**

* Changed the logic in `AssistantChatMessage.razor` so highlighted assistant messages use the `Info` color instead of `Primary`, reflecting the new color assignments.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enhances chat UI contrast and readability, especially for assistant and highlighted messages.
> 
> - Updates theme: sets `Tertiary` to teal and uses `Info` (cyan) for highlighted content
> - Assistant messages: `AssistantChatMessage.razor` now uses `Color.Info` when `Highlighted`
> - Restyles chat bubbles in `app.css`: soft teal default for assistant, adds `chat-bubble-tertiary`, and adjusts `primary`, `secondary`, `info`, etc. with lighter backgrounds and contrast borders
> - Refines bubble pointers: shifts positions and sets explicit colors for `primary`, `secondary`, `tertiary`, and `info` variants
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5243a45c11d4984d9ada91f3a98bbe848c9e3113. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->